### PR TITLE
[codex] Enrich ticker dossier metadata

### DIFF
--- a/.agent/session-state.md
+++ b/.agent/session-state.md
@@ -1,31 +1,34 @@
 # Session State
 
-**Updated:** 2026-05-04 17:56:00 +02:00
+**Updated:** 2026-05-04 20:03:30 +02:00
 **Agent:** Codex CLI
 **Project:** C:\Projects\03-Finance\ai-fund
 
 ## Current Task
-Publish the finalized `TickerDossier` branch and draft PR.
+Implement issue #20 as a stacked follow-up on PR #37: enrich canonical `TickerDossier` identity, QoE, and historical series metadata from existing export/archive payload fields.
 
 ## Recent Actions
-- Confirmed the local branch was `19-feature-ticker-dossier-contract` at commit `eb06e60 finalizing the ticker dossier`.
-- Pushed the branch to `origin` and set upstream tracking.
-- Opened draft PR `https://github.com/smrik/ai-fund/pull/37`.
+- Created branch `20-dossier-metadata-qoe-history` from `19-feature-ticker-dossier-contract`.
+- Updated `src/stage_04_pipeline/ticker_dossier.py` to map additive company identity metadata, existing QoE payloads, and existing revenue/EBIT/margin/FCFF series into `latest_snapshot`.
+- Updated `docs/design-docs/ticker-dossier-contract.md` to document v1 enrichment as adapter-level mapping only, with no new live data collection path.
+- Added focused runtime, export-service, persistence, and docs contract tests for the enriched payload behavior.
+- Committed the work, pushed `20-dossier-metadata-qoe-history`, then rebased it onto `origin/main` after PR #37 was confirmed merged.
+- Opened draft PR `https://github.com/smrik/ai-fund/pull/38`.
+- Documented the Codex/Windows pre-commit cache workaround in `AGENTS.md` and ran pre-commit with `PRE_COMMIT_HOME=.pre-commit-cache-run-codex`.
 
 ## Next Steps
-- Wait for review or CI feedback on the draft PR.
-- Refresh the branch locally from GitHub before any follow-up changes if needed.
+- Wait for CI/review feedback on PR #38.
+- If CI fails, inspect the failing check logs before changing code.
 
 ## Known Issues
-- `rtk pytest ...` shorthand still fails to import local packages in this repo; use `rtk python -m pytest ...`.
-- Pytest still emits a local `.pytest_cache` permission warning under `C:\Projects\03-Finance\ai-fund\.pytest_cache`.
-- MkDocs strict build reports pre-existing nav warnings for `docs/other/Valuation pseudo-code.md` and `docs/other/deterministic-valuation-workflow.md`, but exits successfully.
+- Pytest still emits the known local `.pytest_cache` permission warning.
+- MkDocs strict build still reports pre-existing nav warnings for `docs/other/Valuation pseudo-code.md` and `docs/other/deterministic-valuation-workflow.md`, but exits successfully.
 
 ## Notes
-- No valuation math was changed.
-- No v1 backfill was added; existing archive rows remain untouched until a new ticker export is built.
+- No valuation math, DB schema, API routes, live fetches, QoE LLM calls, or backfill paths were added.
 - Verification run in this session:
-  - `rtk python -m pytest tests/test_ticker_dossier_contract_runtime.py tests/test_ticker_dossier_contract_docs.py tests/test_api_contracts.py -q` -> 19 passed
-  - `rtk python -m pytest tests/test_export_service.py tests/test_ticker_dossier_persistence.py -q` -> 10 passed
+  - `rtk python -m pytest tests/test_ticker_dossier_contract_runtime.py tests/test_ticker_dossier_persistence.py tests/test_export_service.py -q` -> 14 passed
+  - `rtk python -m pytest tests/test_api_contracts.py tests/test_ticker_dossier_contract_docs.py -q` -> 17 passed
   - `rtk git diff --check` -> passed
   - `rtk python -m mkdocs build --strict` -> passed with the pre-existing docs/other nav warnings above
+  - `$env:PRE_COMMIT_HOME = "$PWD\.pre-commit-cache-run-codex"; rtk pre-commit run --all-files` -> passed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,17 @@ Before starting a new branch or ending a major work session:
 5. If the user says they want to “start fresh” or “branch properly”, pause and verify Git hygiene before doing anything else
 6. When in doubt, babysit the workflow: explain whether `main` is clean, whether GitHub matches local, and what the next safe git step is
 
+## Pre-Commit On This Machine
+
+The default user pre-commit cache can be readonly in Codex/Windows sandbox sessions. If `pre-commit` fails with `attempt to write a readonly database` or cannot write `C:\Users\patri\.cache\pre-commit\pre-commit.log`, rerun it with a workspace-local cache:
+
+```powershell
+$env:PRE_COMMIT_HOME = "$PWD\.pre-commit-cache-run-codex"
+rtk pre-commit run --all-files
+```
+
+`.pre-commit-cache-run*/` is ignored by Git, so the local hook cache should not pollute commits.
+
 ## Project Structure
 
 ```text

--- a/docs/design-docs/ticker-dossier-contract.md
+++ b/docs/design-docs/ticker-dossier-contract.md
@@ -288,6 +288,12 @@ It is the target for:
 
 The current runtime path is intentionally additive: API and export callers can consume `ticker_dossier` while the legacy fields remain stable.
 
+## V1 Adapter Enrichment
+
+The v1 enrichment path is adapter-level mapping of fields that already exist in export or archive payloads. It may lift company identity metadata such as `industry`, `exchange`, `description`, and `country`; QoE context from an existing `qoe` block; and historical revenue, EBIT, margin, and FCFF series from existing payload sections.
+
+This is not a new data collection path. Building or reading a `TickerDossier` must not call yfinance, CIQ refresh, EDGAR, QoE LLMs, or batch valuation just to fill enrichment fields. Missing QoE or history remains a valid payload state: QoE uses `present=false`, and missing historical series stay as empty lists.
+
 ## Persistence
 
 Canonical dossier payloads are persisted additively in `ticker_dossier_snapshots`.

--- a/docs/exec-plans/completed/2026-03-08-deterministic-audit-master-todo.md
+++ b/docs/exec-plans/completed/2026-03-08-deterministic-audit-master-todo.md
@@ -12,7 +12,7 @@ Run a correctness-first audit of every valuation process:
 - revenue and historical financial sourcing
 - projection logic by driver
 - WACC derivation
-- comps valuation
+- comps valuationw
 - one-off handling boundaries
 - output lineage and reproducibility
 
@@ -34,52 +34,52 @@ Each feature must pass the same 7-step loop:
 
 ## Feature Inventory
 
-| ID | Feature To Audit | Financial Logic Focus | Coding Logic Focus | Status |
-|---|---|---|---|---|
-| F01 | Revenue and period normalization | TTM vs annual alignment, growth base integrity | `market_data.py` extraction + normalization boundaries | Completed (Tranche 1) |
-| F02 | Historical financial extraction integrity | Capex/D&A sign, NWC construction, tax denominator correctness | `market_data.py` row mapping, missing-key fallback safety | Completed (Tranche 1) |
-| F03 | CIQ workbook contract and ingestion | Deterministic source-of-truth ingestion semantics | `ciq/workbook_parser.py`, `ciq/ingest.py` template lock + idempotency | Not started |
-| F04 | CIQ snapshot adapter mapping | Canonical field mapping into valuation inputs | `stage_00_data/ciq_adapter.py` mapping + fallback merge | Not started |
-| F05 | Assumption precedence and lineage | CIQ > yfinance > default > override consistency | `input_assembler.py` `_pick`, lineage coverage, override stamps | Not started |
-| F06 | Driver bounds and clipping diagnostics | Realistic ranges for growth/margin/tax/NWC drivers | `input_assembler.py` bounds + explicit flags | Not started |
-| F07 | WACC engine correctness | CAPM, unlever/relever beta, debt cost, size premia | `wacc.py` math paths, no-peer/zero-debt paths, audit fields | Not started |
-| F08 | DCF projection engine | Revenue/margin/tax/reinvestment fade mechanics | `professional_dcf.py` year-path math and FCFF bridge | Not started |
-| F09 | NWC driver framework | DSO/DIO/DPO economics and delta NWC behavior | `professional_dcf.py` NWC component math + validation | Not started |
-| F10 | Terminal value methodology | Gordon + Exit blend, fallback legality, TV concentration | `professional_dcf.py` terminal branch logic + flags | Not started |
-| F11 | Scenario framework and expected IV | Probabilistic weighting quality and decision utility | `professional_dcf.py` scenario normalization + expected value | Not started |
-| F12 | Reverse DCF solver | Implied-growth consistency with forward DCF engine | `professional_dcf.py`, `batch_runner.py` call path unification | Not started |
-| F13 | Comps valuation pipeline | Peer multiple relevance and denominator hygiene | `ciq_adapter.py`, `batch_runner.py` comps input usage | Not started |
-| F14 | One-off exclusion boundary (QoE) | Recurring vs non-recurring treatment control | `qoe_agent.py` contract + deterministic acceptance boundary | Not started |
-| F15 | Batch output contract and persistence | Auditability for PM review and reproducibility | `batch_runner.py`, SQLite persistence, CSV/XLSX exports | Not started |
-| F16 | Screening and architecture integration | Screen/valuation coherence and deterministic boundary enforcement | `stage1_filter.py`, `stage2_filter.py`, boundary tests | Not started |
+| ID  | Feature To Audit                          | Financial Logic Focus                                             | Coding Logic Focus                                                    | Status                |
+| --- | ----------------------------------------- | ----------------------------------------------------------------- | --------------------------------------------------------------------- | --------------------- |
+| F01 | Revenue and period normalization          | TTM vs annual alignment, growth base integrity                    | `market_data.py` extraction + normalization boundaries                | Completed (Tranche 1) |
+| F02 | Historical financial extraction integrity | Capex/D&A sign, NWC construction, tax denominator correctness     | `market_data.py` row mapping, missing-key fallback safety             | Completed (Tranche 1) |
+| F03 | CIQ workbook contract and ingestion       | Deterministic source-of-truth ingestion semantics                 | `ciq/workbook_parser.py`, `ciq/ingest.py` template lock + idempotency | Not started           |
+| F04 | CIQ snapshot adapter mapping              | Canonical field mapping into valuation inputs                     | `stage_00_data/ciq_adapter.py` mapping + fallback merge               | Not started           |
+| F05 | Assumption precedence and lineage         | CIQ > yfinance > default > override consistency                   | `input_assembler.py` `_pick`, lineage coverage, override stamps       | Not started           |
+| F06 | Driver bounds and clipping diagnostics    | Realistic ranges for growth/margin/tax/NWC drivers                | `input_assembler.py` bounds + explicit flags                          | Not started           |
+| F07 | WACC engine correctness                   | CAPM, unlever/relever beta, debt cost, size premia                | `wacc.py` math paths, no-peer/zero-debt paths, audit fields           | Not started           |
+| F08 | DCF projection engine                     | Revenue/margin/tax/reinvestment fade mechanics                    | `professional_dcf.py` year-path math and FCFF bridge                  | Not started           |
+| F09 | NWC driver framework                      | DSO/DIO/DPO economics and delta NWC behavior                      | `professional_dcf.py` NWC component math + validation                 | Not started           |
+| F10 | Terminal value methodology                | Gordon + Exit blend, fallback legality, TV concentration          | `professional_dcf.py` terminal branch logic + flags                   | Not started           |
+| F11 | Scenario framework and expected IV        | Probabilistic weighting quality and decision utility              | `professional_dcf.py` scenario normalization + expected value         | Not started           |
+| F12 | Reverse DCF solver                        | Implied-growth consistency with forward DCF engine                | `professional_dcf.py`, `batch_runner.py` call path unification        | Not started           |
+| F13 | Comps valuation pipeline                  | Peer multiple relevance and denominator hygiene                   | `ciq_adapter.py`, `batch_runner.py` comps input usage                 | Not started           |
+| F14 | One-off exclusion boundary (QoE)          | Recurring vs non-recurring treatment control                      | `qoe_agent.py` contract + deterministic acceptance boundary           | Not started           |
+| F15 | Batch output contract and persistence     | Auditability for PM review and reproducibility                    | `batch_runner.py`, SQLite persistence, CSV/XLSX exports               | Not started           |
+| F16 | Screening and architecture integration    | Screen/valuation coherence and deterministic boundary enforcement | `stage1_filter.py`, `stage2_filter.py`, boundary tests                | Not started           |
 
 ## BUSO97 Step Audit (0-20)
 
 Status legend: `Working` = implemented + test-backed, `Partial` = implemented but not institutional-complete, `Missing` = not implemented in deterministic stack.
 
-| Step | BUSO97 Area | Status | Current Check (Code + Tests) | Gap / TODO |
-|---|---|---|---|---|
-| S00 | High-level valuation philosophy | Partial | DCF outputs EV/Equity/IV and scenario/sensitivity exports in `src/stage_02_valuation/professional_dcf.py` + `src/stage_02_valuation/batch_runner.py`; covered by `tests/test_professional_dcf.py` and `tests/test_batch_runner_professional.py`. | Add deterministic Economic Profit cross-check to fully match BUSO97 dual-method philosophy. |
-| S01 | Master valuation algorithm end-to-end | Partial | Pipeline exists: `build_valuation_inputs()` -> `run_probabilistic_valuation()` -> `reverse_dcf_professional()` in `src/stage_02_valuation/`; batch orchestration in `value_single_ticker()` (`batch_runner.py`). | Missing explicit modules for business narrative translation, full accounting recast, and EP reconciliation stage. |
-| S02 | Business + industry understanding | Partial | Sector/industry pulled from yfinance in `src/stage_00_data/market_data.py`; sector policy/exit metric mapping in `input_assembler.py`; Stage 2 quality filter in `src/stage_01_screening/stage2_filter.py`. | Add deterministic narrative-to-driver framework (competitive position, cyclicality, moat duration) as structured inputs, not implicit defaults. |
-| S03 | Recast and adjust financial statements | Partial | Current adjustments: capex sign normalization, tax sign robustness, NWC derivation in `get_historical_financials()` (`market_data.py`); CIQ normalization in `ciq/workbook_parser.py`; QoE agent contract in `src/stage_03_judgment/qoe_agent.py`. | Missing full operating vs financing recast (leases, pensions, excess cash separation, debt-like claims); QoE not yet wired into deterministic input assembler boundary. |
-| S04 | Historical performance analysis | Working (core) | Historical metrics produced in `market_data.py` (`revenue_cagr_3yr`, margins, capex/DA ratios, DSO/DIO/DPO, tax, cost of debt); CIQ historical extraction in `workbook_parser.py`. Tested by `tests/test_market_data.py`, `tests/test_ciq_parser.py`. | Add explicit historical ROIC decomposition table and trend diagnostics artifact in output. |
-| S05 | Forecast pro forma build | Working (core) | 10-year deterministic forecast with growth/margin/tax/capex/DA/NWC trajectories in `run_dcf_professional()` (`professional_dcf.py`). | Add explicit forecast horizon policy object (mature vs high-growth horizon selection) and optional invested-capital-turnover projection mode. |
-| S06 | Cost of capital (WACC) | Working | CAPM + unlever/relever beta + size premium + capital structure weighting in `src/stage_02_valuation/wacc.py`; tests in `tests/test_wacc.py` (beta math, fallbacks, zero-debt, audit fields). | Add country risk premium and explicit target capital-structure policy override hooks. |
-| S07 | FCFF computation | Working | FCFF bridge (`NOPAT + D&A - CapEx - dNWC`) implemented in `run_dcf_professional()`; validated in `tests/test_professional_dcf.py` (`test_nwc_driver_bridge_uses_dso_dio_dpo_identity`). | Add optional alternate FCFF presentation (NOPAT - delta invested capital) in exports for audit readability. |
-| S08 | Continuing/terminal value | Partial | Gordon + Exit computed each run with deterministic blend and fallback in `professional_dcf.py`; tested in `tests/test_professional_dcf.py` (`test_terminal_blend_fallback_when_gordon_invalid`). | Add value-driver terminal formula (`NOPAT*(1-g/RONIC)/(WACC-g)`) and explicit stable-state economic constraints report. |
-| S09 | Discounting to present value | Working | PV of yearly FCFF + PV terminal in `run_dcf_professional()` with per-year `discount_factor` and `pv_fcff`. | Add timing-policy switch (mid-year vs end-year) and coverage tests for timing convention. |
-| S10 | EV -> Equity bridge | Partial | Current bridge is `equity_value = enterprise_value - net_debt` in `professional_dcf.py`; net debt sourced with lineage in `input_assembler.py`. | Add full bridge: non-operating assets, minority interest, preferreds, leases, pension deficits, option dilution adjustments. |
-| S11 | Value per share computation | Working (core) | Per-share IV computed via `equity_value / shares_outstanding` in `professional_dcf.py`; shares lineage handled in `input_assembler.py`; surfaced in batch outputs. | Add diluted-share schedule support (options/converts/TSM) instead of single shares field. |
-| S12 | Economic Profit method cross-check | Missing | No deterministic EP valuation module or DCF-vs-EP reconciliation artifact currently. | Implement `run_economic_profit_valuation()` and reconciliation flags/output columns. |
-| S13 | Diagnostics + sanity checks | Partial | Current diagnostics: `tv_pct_of_ev`, `tv_high_flag`, `roic_consistency_flag`, `nwc_driver_quality_flag`, lineage flags in `batch_runner.py` + `professional_dcf.py`; tests in `test_batch_runner_professional.py`. | Add structured realism checks (terminal growth vs macro cap, margin vs peer bounds, valuation-vs-comps reasonability deltas). |
-| S14 | Sensitivity + scenario analysis | Working | Scenario engine in `run_probabilistic_valuation()` + default bear/base/bull; 2D sensitivity grids in `_sensitivity_rows()` and Excel export tabs. Tests in `tests/test_professional_dcf.py` and `tests/test_batch_runner_professional.py`. | Extend to configurable scenario sets and ticker/sector-specific probability policies. |
-| S15 | Alternative FCFE branch | Missing | No FCFE valuation path currently in deterministic compute layer. | Implement optional FCFE engine for cases where equity-cash-flow framework is preferred. |
-| S16 | Compact exam-style valuation flow | Partial | Process spread across code/docs; this BUSO97 checklist now maps it end-to-end. | Add a single deterministic flow spec doc in `docs/design-docs/` with exact contract objects and formulas. |
-| S17 | Mini-glossary of key variables | Partial | Terms appear in code/dataclasses (`ForecastDrivers`, `DCFComputationResult`) and docs, but no canonical glossary file tied to the model schema. | Add `docs/reference/valuation-glossary.md` with formula + field-name mapping. |
-| S18 | Common valuation mistake controls | Partial | Bounds validation, fallback flags, deterministic tests exist (`professional_dcf.py`, `input_assembler.py`, `test_professional_dcf.py`, `test_valuation_input_assembler.py`). | Add explicit "mistake guardrail" checks/report rows (e.g., FCFF-interest contamination, TV dominance threshold tiers, denominator mismatch alerts). |
-| S19 | Story-to-numbers mapping | Partial | Current mapping is sector defaults + CIQ/yfinance precedence + manual overrides (`input_assembler.py`, `config/valuation_overrides.yaml`). | Add structured thesis-driver schema so assumptions are traceable to named strategic hypotheses. |
-| S20 | One-line summary formula logic | Partial | DCF one-line logic implemented (PV FCFF + PV TV; per-share IV). | Add EP one-line logic side-by-side in outputs so both formula families are always reconcilable. |
+| Step | BUSO97 Area                            | Status         | Current Check (Code + Tests)                                                                                                                                                                                                                          | Gap / TODO                                                                                                                                                              |
+| ---- | -------------------------------------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| S00  | High-level valuation philosophy        | Partial        | DCF outputs EV/Equity/IV and scenario/sensitivity exports in `src/stage_02_valuation/professional_dcf.py` + `src/stage_02_valuation/batch_runner.py`; covered by `tests/test_professional_dcf.py` and `tests/test_batch_runner_professional.py`.      | Add deterministic Economic Profit cross-check to fully match BUSO97 dual-method philosophy.                                                                             |
+| S01  | Master valuation algorithm end-to-end  | Partial        | Pipeline exists: `build_valuation_inputs()` -> `run_probabilistic_valuation()` -> `reverse_dcf_professional()` in `src/stage_02_valuation/`; batch orchestration in `value_single_ticker()` (`batch_runner.py`).                                      | Missing explicit modules for business narrative translation, full accounting recast, and EP reconciliation stage.                                                       |
+| S02  | Business + industry understanding      | Partial        | Sector/industry pulled from yfinance in `src/stage_00_data/market_data.py`; sector policy/exit metric mapping in `input_assembler.py`; Stage 2 quality filter in `src/stage_01_screening/stage2_filter.py`.                                           | Add deterministic narrative-to-driver framework (competitive position, cyclicality, moat duration) as structured inputs, not implicit defaults.                         |
+| S03  | Recast and adjust financial statements | Partial        | Current adjustments: capex sign normalization, tax sign robustness, NWC derivation in `get_historical_financials()` (`market_data.py`); CIQ normalization in `ciq/workbook_parser.py`; QoE agent contract in `src/stage_03_judgment/qoe_agent.py`.    | Missing full operating vs financing recast (leases, pensions, excess cash separation, debt-like claims); QoE not yet wired into deterministic input assembler boundary. |
+| S04  | Historical performance analysis        | Working (core) | Historical metrics produced in `market_data.py` (`revenue_cagr_3yr`, margins, capex/DA ratios, DSO/DIO/DPO, tax, cost of debt); CIQ historical extraction in `workbook_parser.py`. Tested by `tests/test_market_data.py`, `tests/test_ciq_parser.py`. | Add explicit historical ROIC decomposition table and trend diagnostics artifact in output.                                                                              |
+| S05  | Forecast pro forma build               | Working (core) | 10-year deterministic forecast with growth/margin/tax/capex/DA/NWC trajectories in `run_dcf_professional()` (`professional_dcf.py`).                                                                                                                  | Add explicit forecast horizon policy object (mature vs high-growth horizon selection) and optional invested-capital-turnover projection mode.                           |
+| S06  | Cost of capital (WACC)                 | Working        | CAPM + unlever/relever beta + size premium + capital structure weighting in `src/stage_02_valuation/wacc.py`; tests in `tests/test_wacc.py` (beta math, fallbacks, zero-debt, audit fields).                                                          | Add country risk premium and explicit target capital-structure policy override hooks.                                                                                   |
+| S07  | FCFF computation                       | Working        | FCFF bridge (`NOPAT + D&A - CapEx - dNWC`) implemented in `run_dcf_professional()`; validated in `tests/test_professional_dcf.py` (`test_nwc_driver_bridge_uses_dso_dio_dpo_identity`).                                                               | Add optional alternate FCFF presentation (NOPAT - delta invested capital) in exports for audit readability.                                                             |
+| S08  | Continuing/terminal value              | Partial        | Gordon + Exit computed each run with deterministic blend and fallback in `professional_dcf.py`; tested in `tests/test_professional_dcf.py` (`test_terminal_blend_fallback_when_gordon_invalid`).                                                      | Add value-driver terminal formula (`NOPAT*(1-g/RONIC)/(WACC-g)`) and explicit stable-state economic constraints report.                                                 |
+| S09  | Discounting to present value           | Working        | PV of yearly FCFF + PV terminal in `run_dcf_professional()` with per-year `discount_factor` and `pv_fcff`.                                                                                                                                            | Add timing-policy switch (mid-year vs end-year) and coverage tests for timing convention.                                                                               |
+| S10  | EV -> Equity bridge                    | Partial        | Current bridge is `equity_value = enterprise_value - net_debt` in `professional_dcf.py`; net debt sourced with lineage in `input_assembler.py`.                                                                                                       | Add full bridge: non-operating assets, minority interest, preferreds, leases, pension deficits, option dilution adjustments.                                            |
+| S11  | Value per share computation            | Working (core) | Per-share IV computed via `equity_value / shares_outstanding` in `professional_dcf.py`; shares lineage handled in `input_assembler.py`; surfaced in batch outputs.                                                                                    | Add diluted-share schedule support (options/converts/TSM) instead of single shares field.                                                                               |
+| S12  | Economic Profit method cross-check     | Missing        | No deterministic EP valuation module or DCF-vs-EP reconciliation artifact currently.                                                                                                                                                                  | Implement `run_economic_profit_valuation()` and reconciliation flags/output columns.                                                                                    |
+| S13  | Diagnostics + sanity checks            | Partial        | Current diagnostics: `tv_pct_of_ev`, `tv_high_flag`, `roic_consistency_flag`, `nwc_driver_quality_flag`, lineage flags in `batch_runner.py` + `professional_dcf.py`; tests in `test_batch_runner_professional.py`.                                    | Add structured realism checks (terminal growth vs macro cap, margin vs peer bounds, valuation-vs-comps reasonability deltas).                                           |
+| S14  | Sensitivity + scenario analysis        | Working        | Scenario engine in `run_probabilistic_valuation()` + default bear/base/bull; 2D sensitivity grids in `_sensitivity_rows()` and Excel export tabs. Tests in `tests/test_professional_dcf.py` and `tests/test_batch_runner_professional.py`.            | Extend to configurable scenario sets and ticker/sector-specific probability policies.                                                                                   |
+| S15  | Alternative FCFE branch                | Missing        | No FCFE valuation path currently in deterministic compute layer.                                                                                                                                                                                      | Implement optional FCFE engine for cases where equity-cash-flow framework is preferred.                                                                                 |
+| S16  | Compact exam-style valuation flow      | Partial        | Process spread across code/docs; this BUSO97 checklist now maps it end-to-end.                                                                                                                                                                        | Add a single deterministic flow spec doc in `docs/design-docs/` with exact contract objects and formulas.                                                               |
+| S17  | Mini-glossary of key variables         | Partial        | Terms appear in code/dataclasses (`ForecastDrivers`, `DCFComputationResult`) and docs, but no canonical glossary file tied to the model schema.                                                                                                       | Add `docs/reference/valuation-glossary.md` with formula + field-name mapping.                                                                                           |
+| S18  | Common valuation mistake controls      | Partial        | Bounds validation, fallback flags, deterministic tests exist (`professional_dcf.py`, `input_assembler.py`, `test_professional_dcf.py`, `test_valuation_input_assembler.py`).                                                                          | Add explicit "mistake guardrail" checks/report rows (e.g., FCFF-interest contamination, TV dominance threshold tiers, denominator mismatch alerts).                     |
+| S19  | Story-to-numbers mapping               | Partial        | Current mapping is sector defaults + CIQ/yfinance precedence + manual overrides (`input_assembler.py`, `config/valuation_overrides.yaml`).                                                                                                            | Add structured thesis-driver schema so assumptions are traceable to named strategic hypotheses.                                                                         |
+| S20  | One-line summary formula logic         | Partial        | DCF one-line logic implemented (PV FCFF + PV TV; per-share IV).                                                                                                                                                                                       | Add EP one-line logic side-by-side in outputs so both formula families are always reconcilable.                                                                         |
 
 ## BUSO97 Priority Queue (Next Tranche)
 
@@ -93,6 +93,7 @@ Status legend: `Working` = implemented + test-backed, `Partial` = implemented bu
 ## Per-Feature 7-Step Checklist
 
 ### F01 Revenue and period normalization
+
 - [x] 1. Check current implementation
 - [x] 2. Compare to best practices
 - [x] 3. Add missing features/logic
@@ -102,6 +103,7 @@ Status legend: `Working` = implemented + test-backed, `Partial` = implemented bu
 - [x] 7. Proceed
 
 ### F02 Historical financial extraction integrity
+
 - [x] 1. Check current implementation
 - [x] 2. Compare to best practices
 - [x] 3. Add missing features/logic
@@ -111,6 +113,7 @@ Status legend: `Working` = implemented + test-backed, `Partial` = implemented bu
 - [x] 7. Proceed
 
 ### F03 CIQ workbook contract and ingestion
+
 - [ ] 1. Check current implementation
 - [ ] 2. Compare to best practices
 - [ ] 3. Add missing features/logic
@@ -120,6 +123,7 @@ Status legend: `Working` = implemented + test-backed, `Partial` = implemented bu
 - [ ] 7. Proceed
 
 ### F04 CIQ snapshot adapter mapping
+
 - [ ] 1. Check current implementation
 - [ ] 2. Compare to best practices
 - [ ] 3. Add missing features/logic
@@ -129,6 +133,7 @@ Status legend: `Working` = implemented + test-backed, `Partial` = implemented bu
 - [ ] 7. Proceed
 
 ### F05 Assumption precedence and lineage
+
 - [ ] 1. Check current implementation
 - [ ] 2. Compare to best practices
 - [ ] 3. Add missing features/logic
@@ -138,6 +143,7 @@ Status legend: `Working` = implemented + test-backed, `Partial` = implemented bu
 - [ ] 7. Proceed
 
 ### F06 Driver bounds and clipping diagnostics
+
 - [ ] 1. Check current implementation
 - [ ] 2. Compare to best practices
 - [ ] 3. Add missing features/logic
@@ -147,6 +153,7 @@ Status legend: `Working` = implemented + test-backed, `Partial` = implemented bu
 - [ ] 7. Proceed
 
 ### F07 WACC engine correctness
+
 - [ ] 1. Check current implementation
 - [ ] 2. Compare to best practices
 - [ ] 3. Add missing features/logic
@@ -156,6 +163,7 @@ Status legend: `Working` = implemented + test-backed, `Partial` = implemented bu
 - [ ] 7. Proceed
 
 ### F08 DCF projection engine
+
 - [ ] 1. Check current implementation
 - [ ] 2. Compare to best practices
 - [ ] 3. Add missing features/logic
@@ -165,6 +173,7 @@ Status legend: `Working` = implemented + test-backed, `Partial` = implemented bu
 - [ ] 7. Proceed
 
 ### F09 NWC driver framework
+
 - [ ] 1. Check current implementation
 - [ ] 2. Compare to best practices
 - [ ] 3. Add missing features/logic
@@ -174,6 +183,7 @@ Status legend: `Working` = implemented + test-backed, `Partial` = implemented bu
 - [ ] 7. Proceed
 
 ### F10 Terminal value methodology
+
 - [ ] 1. Check current implementation
 - [ ] 2. Compare to best practices
 - [ ] 3. Add missing features/logic
@@ -183,6 +193,7 @@ Status legend: `Working` = implemented + test-backed, `Partial` = implemented bu
 - [ ] 7. Proceed
 
 ### F11 Scenario framework and expected IV
+
 - [ ] 1. Check current implementation
 - [ ] 2. Compare to best practices
 - [ ] 3. Add missing features/logic
@@ -192,6 +203,7 @@ Status legend: `Working` = implemented + test-backed, `Partial` = implemented bu
 - [ ] 7. Proceed
 
 ### F12 Reverse DCF solver
+
 - [ ] 1. Check current implementation
 - [ ] 2. Compare to best practices
 - [ ] 3. Add missing features/logic
@@ -201,6 +213,7 @@ Status legend: `Working` = implemented + test-backed, `Partial` = implemented bu
 - [ ] 7. Proceed
 
 ### F13 Comps valuation pipeline
+
 - [ ] 1. Check current implementation
 - [ ] 2. Compare to best practices
 - [ ] 3. Add missing features/logic
@@ -210,6 +223,7 @@ Status legend: `Working` = implemented + test-backed, `Partial` = implemented bu
 - [ ] 7. Proceed
 
 ### F14 One-off exclusion boundary (QoE)
+
 - [ ] 1. Check current implementation
 - [ ] 2. Compare to best practices
 - [ ] 3. Add missing features/logic
@@ -219,6 +233,7 @@ Status legend: `Working` = implemented + test-backed, `Partial` = implemented bu
 - [ ] 7. Proceed
 
 ### F15 Batch output contract and persistence
+
 - [ ] 1. Check current implementation
 - [ ] 2. Compare to best practices
 - [ ] 3. Add missing features/logic
@@ -228,6 +243,7 @@ Status legend: `Working` = implemented + test-backed, `Partial` = implemented bu
 - [ ] 7. Proceed
 
 ### F16 Screening and architecture integration
+
 - [ ] 1. Check current implementation
 - [ ] 2. Compare to best practices
 - [ ] 3. Add missing features/logic
@@ -235,11 +251,6 @@ Status legend: `Working` = implemented + test-backed, `Partial` = implemented bu
 - [ ] 5. Brainstorm edge cases
 - [ ] 6. Check downstream impact + TODOs
 - [ ] 7. Proceed
-
-
-
-
-
 
 ## Tranche 2 Update (2026-03-08)
 

--- a/src/stage_04_pipeline/ticker_dossier.py
+++ b/src/stage_04_pipeline/ticker_dossier.py
@@ -36,6 +36,10 @@ def _first_present(*values: Any) -> Any:
     return None
 
 
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
 def _as_float(value: Any) -> float | None:
     if isinstance(value, bool):
         return None
@@ -72,6 +76,132 @@ def _scenario_probability_map(scenarios: dict[str, Any]) -> dict[str, float | No
     }
 
 
+def _as_series(value: Any) -> list[dict[str, Any]]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [dict(item) if isinstance(item, dict) else {"value": item} for item in value]
+    if isinstance(value, dict):
+        nested = value.get("series")
+        if isinstance(nested, list):
+            return _as_series(nested)
+        return [{"period": key, "value": item} for key, item in value.items()]
+    return []
+
+
+def _first_series(*values: Any) -> list[dict[str, Any]]:
+    for value in values:
+        series = _as_series(value)
+        if series:
+            return series
+    return []
+
+
+def _historical_metric_series(comps_analysis: dict[str, Any], *metric_keys: str) -> list[dict[str, Any]]:
+    historical = _as_dict(comps_analysis.get("historical_multiples_summary"))
+    metrics = _as_dict(historical.get("metrics"))
+    for key in metric_keys:
+        series = _as_series(_as_dict(metrics.get(key)).get("series") if isinstance(metrics.get(key), dict) else metrics.get(key))
+        if series:
+            return series
+    return []
+
+
+def _extract_historical_series(payload: dict[str, Any], qoe: dict[str, Any], comps_analysis: dict[str, Any]) -> HistoricalSeries:
+    historical = _as_dict(payload.get("historical_series"))
+    drivers_raw = _as_dict(payload.get("drivers_raw"))
+    deterministic_qoe = _as_dict(qoe.get("deterministic"))
+
+    return HistoricalSeries(
+        revenue=_first_series(
+            historical.get("revenue"),
+            historical.get("revenue_series"),
+            drivers_raw.get("revenue_series"),
+            drivers_raw.get("revenue_history"),
+            deterministic_qoe.get("revenue_series"),
+            deterministic_qoe.get("revenue"),
+            _historical_metric_series(comps_analysis, "revenue", "revenue_growth"),
+        ),
+        ebit=_first_series(
+            historical.get("ebit"),
+            historical.get("ebit_series"),
+            historical.get("operating_income"),
+            historical.get("operating_income_series"),
+            drivers_raw.get("ebit_series"),
+            drivers_raw.get("operating_income_series"),
+            deterministic_qoe.get("ebit_series"),
+            deterministic_qoe.get("operating_income_series"),
+            _historical_metric_series(comps_analysis, "ebit", "operating_income"),
+        ),
+        fcff=list(payload.get("forecast_bridge") or []),
+        margin=_first_series(
+            historical.get("margin"),
+            historical.get("margin_series"),
+            historical.get("ebit_margin"),
+            historical.get("ebit_margin_series"),
+            historical.get("operating_margin"),
+            drivers_raw.get("margin_series"),
+            drivers_raw.get("ebit_margin_series"),
+            deterministic_qoe.get("margin_series"),
+            deterministic_qoe.get("ebit_margin_series"),
+            _historical_metric_series(comps_analysis, "margin", "ebit_margin", "operating_margin"),
+        ),
+    )
+
+
+def _append_unique_flags(flags: list[str], values: Any) -> None:
+    raw_values = values if isinstance(values, list) else [values]
+    seen = set(flags)
+    for value in raw_values:
+        if value in (None, False, ""):
+            continue
+        flag = str(value)
+        if flag not in seen:
+            flags.append(flag)
+            seen.add(flag)
+
+
+def _qoe_flags(qoe: dict[str, Any]) -> list[str]:
+    flags: list[str] = []
+    _append_unique_flags(flags, qoe.get("qoe_flag"))
+
+    deterministic = _as_dict(qoe.get("deterministic"))
+    signal_scores = _as_dict(deterministic.get("signal_scores"))
+    for signal, status in signal_scores.items():
+        if status in (None, "", "green", "unavailable"):
+            continue
+        _append_unique_flags(flags, f"{signal}:{status}")
+
+    llm = _as_dict(qoe.get("llm"))
+    _append_unique_flags(flags, llm.get("revenue_recognition_flags"))
+    _append_unique_flags(flags, llm.get("auditor_flags"))
+
+    if llm.get("dcf_ebit_override_pending") or qoe.get("dcf_ebit_override_pending") or qoe.get("override_warranted"):
+        _append_unique_flags(flags, "dcf_ebit_override_pending")
+    return flags
+
+
+def _qoe_snapshot(qoe: dict[str, Any]) -> QoeSnapshot:
+    if not qoe:
+        return QoeSnapshot()
+
+    llm = _as_dict(qoe.get("llm"))
+    return QoeSnapshot(
+        present=True,
+        score=_as_float(qoe.get("qoe_score")),
+        flags=_qoe_flags(qoe),
+        qoe_flag=qoe.get("qoe_flag"),
+        deterministic=qoe.get("deterministic") or {},
+        llm=llm,
+        pm_summary=qoe.get("pm_summary"),
+        normalized_ebit=llm.get("normalized_ebit"),
+        reported_ebit=llm.get("reported_ebit"),
+        ebit_haircut_pct=llm.get("ebit_haircut_pct"),
+        llm_confidence=llm.get("llm_confidence"),
+        narrative_credibility=llm.get("narrative_credibility"),
+    )
+
+
 def _default_overlays(payload: dict[str, Any]) -> dict[str, Any]:
     legacy_payload_keys = sorted(key for key in payload if key != "ticker_dossier")
     return {
@@ -105,8 +235,7 @@ def build_ticker_dossier_from_export_payload(
     ciq_lineage = payload.get("ciq_lineage") if isinstance(payload.get("ciq_lineage"), dict) else {}
     comps_analysis = payload.get("comps_analysis") if isinstance(payload.get("comps_analysis"), dict) else {}
     peer_counts = comps_analysis.get("peer_counts") if isinstance(comps_analysis.get("peer_counts"), dict) else {}
-    historical_multiples = comps_analysis.get("historical_multiples_summary")
-    historical_metrics = (historical_multiples or {}).get("metrics") if isinstance(historical_multiples, dict) else {}
+    qoe = _as_dict(payload.get("qoe"))
     display_name = str(_first_present(payload.get("company_name"), snapshot.get("company_name"), ticker) or ticker)
     generated_at = payload.get("generated_at")
     as_of_date = str(
@@ -129,9 +258,11 @@ def build_ticker_dossier_from_export_payload(
         company_identity=CompanyIdentity(
             ticker=ticker,
             display_name=display_name,
-            sector=payload.get("sector") or snapshot.get("sector"),
-            industry=payload.get("industry") or snapshot.get("industry"),
-            exchange=payload.get("exchange") or snapshot.get("exchange"),
+            sector=_first_present(payload.get("sector"), snapshot.get("sector"), market.get("sector")),
+            industry=_first_present(payload.get("industry"), snapshot.get("industry"), market.get("industry")),
+            exchange=_first_present(payload.get("exchange"), snapshot.get("exchange"), market.get("exchange")),
+            description=_first_present(payload.get("description"), snapshot.get("description"), market.get("description")),
+            country=_first_present(payload.get("country"), snapshot.get("country"), market.get("country")),
         ),
         market_snapshot=MarketSnapshot(
             as_of_date=as_of_date,
@@ -152,13 +283,8 @@ def build_ticker_dossier_from_export_payload(
             upside_pct=_as_float(_first_present(valuation.get("upside_pct"), valuation.get("upside_pct_base"))),
             scenario_probabilities=_scenario_probability_map(scenarios),
         ),
-        historical_series=HistoricalSeries(
-            fcff=list(payload.get("forecast_bridge") or []),
-            margin=list((historical_metrics or {}).get("margin", {}).get("series") or [])
-            if isinstance((historical_metrics or {}).get("margin"), dict)
-            else [],
-        ),
-        qoe_snapshot=QoeSnapshot(),
+        historical_series=_extract_historical_series(payload, qoe, comps_analysis),
+        qoe_snapshot=_qoe_snapshot(qoe),
         comps_snapshot=CompsSnapshot(
             peer_count=_as_int(_first_present(ciq_lineage.get("peer_count"), peer_counts.get("clean"), peer_counts.get("raw"))),
             primary_metric=comps_analysis.get("primary_metric"),
@@ -187,7 +313,8 @@ def build_ticker_dossier_from_export_payload(
                 "company_identity": "company_name/sector",
                 "market_snapshot": "market",
                 "valuation_snapshot": "valuation/scenarios",
-                "historical_series": "forecast_bridge",
+                "historical_series": "historical_series/drivers_raw/qoe/comps_analysis/forecast_bridge",
+                "qoe_snapshot": "qoe",
                 "comps_snapshot": "comps_analysis/ciq_lineage",
             },
             adapter_state={

--- a/tests/test_export_service.py
+++ b/tests/test_export_service.py
@@ -252,10 +252,24 @@ def test_ticker_exports_persist_current_and_snapshot_dossiers(monkeypatch):
         payload = {
             "ticker": "IBM",
             "company_name": "International Business Machines",
+            "industry": "IT Services",
+            "exchange": "NYSE",
             "generated_at": "2026-04-30T12:00:00+00:00",
             "market": {"price": 260.0},
             "valuation": {"iv_base": 202.0, "expected_iv": 205.0},
             "ciq_lineage": {"snapshot_as_of_date": "2026-04-30"},
+            "forecast_bridge": [{"year": 2027, "fcff": 100.0}],
+            "historical_series": {"revenue": [{"period": "2025", "value": 1000.0}]},
+            "qoe": {
+                "qoe_score": 2.0,
+                "qoe_flag": "red",
+                "deterministic": {"signal_scores": {"dso": "amber"}},
+                "llm": {
+                    "dcf_ebit_override_pending": True,
+                    "revenue_recognition_flags": ["Channel stuffing risk"],
+                    "auditor_flags": [],
+                },
+            },
         }
         dossier = build_ticker_dossier_from_export_payload(payload, source_mode=source_mode, snapshot_id=snapshot_id)
         payload["ticker_dossier"] = ticker_dossier_to_payload(dossier)
@@ -316,3 +330,21 @@ def test_ticker_exports_persist_current_and_snapshot_dossiers(monkeypatch):
         ("latest_snapshot", "snapshot:7"),
         ("loaded_backend_state", "asof:2026-04-30"),
     ]
+
+    payloads = [
+        json.loads(row["payload_json"])
+        for row in conn.execute(
+            """
+            SELECT payload_json
+            FROM ticker_dossier_snapshots
+            ORDER BY source_mode
+            """
+        ).fetchall()
+    ]
+    for dossier_payload in payloads:
+        latest = dossier_payload["latest_snapshot"]
+        assert latest["company_identity"]["industry"] == "IT Services"
+        assert latest["company_identity"]["exchange"] == "NYSE"
+        assert latest["qoe_snapshot"]["present"] is True
+        assert latest["qoe_snapshot"]["flags"] == ["red", "dso:amber", "Channel stuffing risk", "dcf_ebit_override_pending"]
+        assert latest["historical_series"]["revenue"] == [{"period": "2025", "value": 1000.0}]

--- a/tests/test_ticker_dossier_contract_docs.py
+++ b/tests/test_ticker_dossier_contract_docs.py
@@ -37,6 +37,8 @@ def test_ticker_dossier_contract_doc_and_plan_link_are_pinned():
     assert "Required Top-Level Envelope Fields" in contract_doc
     assert "Required Sections" in contract_doc
     assert "Current Runtime Compatibility Roots" in contract_doc
+    assert "V1 Adapter Enrichment" in contract_doc
+    assert "not a new data collection path" in contract_doc
     assert "[docs/design-docs/ticker-dossier-contract.md](../../design-docs/ticker-dossier-contract.md)" in epic_doc
 
     for root in CURRENT_EXPORT_COMMON_ROOTS:

--- a/tests/test_ticker_dossier_contract_runtime.py
+++ b/tests/test_ticker_dossier_contract_runtime.py
@@ -8,6 +8,9 @@ def _legacy_payload() -> dict:
         "ticker": "IBM",
         "company_name": "International Business Machines",
         "sector": "Technology",
+        "industry": "IT Services",
+        "exchange": "NYSE",
+        "country": "United States",
         "market": {"price": 260.0, "analyst_target": 275.0, "analyst_recommendation": "Hold"},
         "assumptions": {},
         "wacc": {},
@@ -45,6 +48,9 @@ def test_ticker_dossier_model_validates_required_envelope_and_round_trips_json()
     assert payload["ticker"] == "IBM"
     assert payload["display_name"] == "International Business Machines"
     assert payload["latest_snapshot"]["company_identity"]["ticker"] == "IBM"
+    assert payload["latest_snapshot"]["company_identity"]["industry"] == "IT Services"
+    assert payload["latest_snapshot"]["company_identity"]["exchange"] == "NYSE"
+    assert payload["latest_snapshot"]["company_identity"]["country"] == "United States"
     assert payload["latest_snapshot"]["market_snapshot"]["price"] == 260.0
     assert payload["latest_snapshot"]["valuation_snapshot"]["base_iv"] == 202.0
     assert payload["latest_snapshot"]["historical_series"]["fcff"][0]["year"] == 2027
@@ -61,6 +67,73 @@ def test_ticker_dossier_model_validates_required_envelope_and_round_trips_json()
         "drift_test_view",
     }
     assert restored == dossier
+
+
+def test_qoe_snapshot_maps_score_flags_and_additive_details():
+    from src.stage_04_pipeline.ticker_dossier import build_ticker_dossier_from_export_payload
+
+    payload = _legacy_payload()
+    payload["qoe"] = {
+        "qoe_score": 2.5,
+        "qoe_flag": "amber",
+        "deterministic": {"signal_scores": {"accruals": "red", "cash_conversion": "green"}},
+        "llm": {
+            "normalized_ebit": 92.0,
+            "reported_ebit": 100.0,
+            "ebit_haircut_pct": -8.0,
+            "dcf_ebit_override_pending": True,
+            "revenue_recognition_flags": ["Bill-and-hold disclosure"],
+            "auditor_flags": ["Auditor change"],
+            "llm_confidence": "medium",
+        },
+        "pm_summary": "QoE needs review.",
+    }
+
+    dossier = build_ticker_dossier_from_export_payload(payload, source_mode="loaded_backend_state")
+    qoe = dossier.model_dump(mode="json")["latest_snapshot"]["qoe_snapshot"]
+
+    assert qoe["present"] is True
+    assert qoe["score"] == 2.5
+    assert qoe["flags"] == [
+        "amber",
+        "accruals:red",
+        "Bill-and-hold disclosure",
+        "Auditor change",
+        "dcf_ebit_override_pending",
+    ]
+    assert qoe["deterministic"]["signal_scores"]["accruals"] == "red"
+    assert qoe["normalized_ebit"] == 92.0
+    assert qoe["pm_summary"] == "QoE needs review."
+
+
+def test_historical_series_maps_existing_payload_sources_and_stays_empty_when_absent():
+    from src.stage_04_pipeline.ticker_dossier import build_ticker_dossier_from_export_payload
+
+    payload = _legacy_payload()
+    payload["historical_series"] = {
+        "revenue": [{"period": "2025", "value": 1000.0}],
+        "ebit": [{"period": "2025", "value": 180.0}],
+    }
+    payload["drivers_raw"] = {
+        "ebit_margin_series": [{"period": "2025", "value": 0.18}],
+    }
+
+    dossier = build_ticker_dossier_from_export_payload(payload, source_mode="loaded_backend_state")
+    series = dossier.model_dump(mode="json")["latest_snapshot"]["historical_series"]
+
+    assert series["revenue"] == [{"period": "2025", "value": 1000.0}]
+    assert series["ebit"] == [{"period": "2025", "value": 180.0}]
+    assert series["margin"] == [{"period": "2025", "value": 0.18}]
+    assert series["fcff"] == [{"year": 2027, "fcff_mm": 100.0}]
+
+    empty_payload = _legacy_payload()
+    empty_payload.pop("forecast_bridge")
+    empty_series = build_ticker_dossier_from_export_payload(
+        empty_payload,
+        source_mode="loaded_backend_state",
+    ).model_dump(mode="json")["latest_snapshot"]["historical_series"]
+
+    assert empty_series == {"revenue": [], "ebit": [], "fcff": [], "margin": []}
 
 
 def test_legacy_workspace_and_summary_payloads_can_be_derived_from_dossier():

--- a/tests/test_ticker_dossier_persistence.py
+++ b/tests/test_ticker_dossier_persistence.py
@@ -33,6 +33,17 @@ def _legacy_payload(company_name: str = "International Business Machines") -> di
         "ciq_lineage": {"snapshot_as_of_date": "2026-04-30"},
         "comps_analysis": {"primary_metric": "tev_ebitda_ltm", "peer_counts": {"raw": 4, "clean": 3}},
         "forecast_bridge": [{"year": 2027, "fcff": 100.0}],
+        "qoe": {
+            "qoe_score": 3.0,
+            "qoe_flag": "green",
+            "deterministic": {"signal_scores": {"accruals": "green"}},
+            "llm": {"revenue_recognition_flags": [], "auditor_flags": []},
+        },
+        "historical_series": {
+            "revenue": [{"period": "2025", "value": 1000.0}],
+            "ebit": [{"period": "2025", "value": 180.0}],
+            "margin": [{"period": "2025", "value": 0.18}],
+        },
     }
 
 
@@ -89,6 +100,9 @@ def test_ticker_dossier_persistence_round_trips_validated_payload():
 
     assert loaded is not None
     assert loaded.model_dump(mode="json") == payload
+    assert loaded.latest_snapshot.qoe_snapshot.present is True
+    assert loaded.latest_snapshot.qoe_snapshot.score == 3.0
+    assert loaded.latest_snapshot.historical_series.revenue == [{"period": "2025", "value": 1000.0}]
 
 
 def test_ticker_dossier_upsert_updates_same_source_key_without_duplicates():


### PR DESCRIPTION
Builds on merged PR #37. Closes #20. Adds adapter-level enrichment for TickerDossier identity metadata, QoE snapshots, and historical series using existing export/archive payload fields only. Keeps legacy export roots stable and avoids live fetches, LLM runs, schema changes, and API route changes. Also documents the Codex/Windows pre-commit cache workaround in AGENTS.md after reproducing the readonly user-cache failure. Validation: rtk python -m pytest tests/test_ticker_dossier_contract_runtime.py tests/test_ticker_dossier_persistence.py tests/test_export_service.py -q; rtk python -m pytest tests/test_api_contracts.py tests/test_ticker_dossier_contract_docs.py -q; rtk git diff --check; rtk python -m mkdocs build --strict; $env:PRE_COMMIT_HOME = $PWD\.pre-commit-cache-run-codex; rtk pre-commit run --all-files.