### PR TITLE
feat: align dossier consumers

### DIFF
--- a/.agent/session-state.md
+++ b/.agent/session-state.md
@@ -1,34 +1,35 @@
 # Session State
 
-**Updated:** 2026-05-04 23:30:00 +02:00
+**Updated:** 2026-05-05 00:44:36 +02:00
 **Agent:** Codex CLI
 **Project:** C:\Projects\03-Finance\ai-fund
 
 ## Current Task
-Implement GitHub issue #21: repair sensitivity and comparables support data contract under Epic #14.
+Implement GitHub issue #22: align API, React preload, and export consumers to the canonical `TickerDossier` envelope under Epic #14.
 
 ## Recent Actions
-- Confirmed issue #19 is already closed.
-- Created branch `21-sensitivity-comps-contract` from clean `main`.
-- Added canonical sensitivity support metadata in `src/stage_04_pipeline/dcf_audit.py`: axis metadata, long-form sensitivity cells, base-case markers, and per-grid summaries while preserving legacy matrix keys.
-- Enriched comps support data in `src/stage_04_pipeline/comps_dashboard.py`: derived operating context, leverage fields, peer coverage diagnostics, and no-patchup support metadata.
-- Added `sensitivity` as a stable export payload root in `src/stage_04_pipeline/export_service.py` for current and archived ticker payloads.
-- Updated the comps workbook peer table to include revenue, EBITDA, and EBIT support columns.
-- Updated dossier contract docs and the Epic #14 plan doc.
-- Opened draft PR `https://github.com/smrik/ai-fund/pull/39`.
+- Synced local `main` to `origin/main` after PR #39 and created branch `22-canonical-dossier-consumers`.
+- Updated `api/main.py` so workspace, overview, and valuation summary payloads reuse one loaded dossier and prefer canonical company, market, valuation, as-of, and snapshot metadata while preserving PM action/conviction, memo, tracker, market narrative, readiness, and DCF audit fields.
+- Added frontend canonical normalization in `frontend/src/lib/canonical.ts` and routed workspace, overview, valuation summary, and opened snapshot payloads through it.
+- Updated HTML export context in `src/stage_04_pipeline/export_service.py` to derive scalar company/valuation/source metadata from the attached `ticker_dossier`.
+- Updated dossier contract docs and the Epic #14 note for #22 consumer alignment.
+- Added backend, export, and React tests with intentionally divergent legacy vs canonical fixture values.
 
 ## Next Steps
-- Wait for CI/review feedback on PR #39.
-- If PR #39 merges, proceed to issue #22 consumer alignment.
+- Review the diff, then commit and open the issue #22 PR when ready.
+- After merge, do the Epic #14 closure check for #19, #20, #21, and #22 before closing the epic.
 
 ## Known Issues
 - Pytest still emits the known local `.pytest_cache` permission warning.
 - MkDocs strict build still reports pre-existing nav warnings for `docs/other/Valuation pseudo-code.md` and `docs/other/deterministic-valuation-workflow.md`, but exits successfully.
+- Vitest and Vite build need elevated/sandbox-external execution on this machine because esbuild helper spawn fails with `EPERM` inside the default sandbox.
 
 ## Notes
-- No valuation math, DB schema, API routes, live fetches, or LLM paths were added.
+- No DB schema changes, contract version bump, API routes, live fetches, valuation math changes, or LLM calls were added.
 - Verification run in this session:
-  - `rtk python -m pytest tests/test_api_contracts.py tests/test_ticker_dossier_contract_docs.py tests/test_dcf_audit.py tests/test_comps_dashboard.py tests/test_export_service.py -q` -> 27 passed
+  - `rtk python -m pytest tests/test_api_contracts.py tests/test_export_service.py tests/test_ticker_dossier_contract_runtime.py tests/test_ticker_dossier_contract_docs.py -q` -> 29 passed
+  - `rtk npm --prefix frontend run test -- appRoutes.test.tsx exportFlows.test.tsx` -> 14 passed
+  - `rtk npm --prefix frontend run build` -> passed
   - `rtk git diff --check` -> passed
   - `rtk python -m mkdocs build --strict` -> passed with the pre-existing docs/other nav warnings above
   - `$env:PRE_COMMIT_HOME = "$PWD\.pre-commit-cache-run-codex"; rtk pre-commit run --all-files` -> passed

--- a/api/main.py
+++ b/api/main.py
@@ -195,14 +195,45 @@ def build_ticker_dossier_payload(ticker: str, source_mode: str | None = None) ->
         return build_ticker_dossier_from_source(ticker, SOURCE_MODE_LOADED_BACKEND_STATE)
 
 
-def _attach_api_ticker_dossier(payload: dict[str, Any], ticker: str, source_mode: str | None = None) -> dict[str, Any]:
-    try:
-        dossier = build_ticker_dossier_payload(ticker, source_mode=source_mode)
-    except Exception:  # pragma: no cover - compatibility shim must not hide legacy endpoints
+_DOSSIER_NOT_PROVIDED = object()
+
+
+def _attach_api_ticker_dossier(
+    payload: dict[str, Any],
+    ticker: str,
+    source_mode: str | None = None,
+    dossier_payload: dict[str, Any] | None | object = _DOSSIER_NOT_PROVIDED,
+) -> dict[str, Any]:
+    if dossier_payload is _DOSSIER_NOT_PROVIDED:
+        try:
+            dossier_payload = build_ticker_dossier_payload(ticker, source_mode=source_mode)
+        except Exception:  # pragma: no cover - compatibility shim must not hide legacy endpoints
+            return payload
+    if not isinstance(dossier_payload, dict):
         return payload
-    payload["ticker_dossier"] = dossier
-    payload["ticker_dossier_contract_version"] = dossier.get("contract_version")
+    payload["ticker_dossier"] = dossier_payload
+    payload["ticker_dossier_contract_version"] = dossier_payload.get("contract_version")
     return payload
+
+
+def _load_api_ticker_dossier_payload(ticker: str, source_mode: str | None = None) -> dict[str, Any] | None:
+    try:
+        return build_ticker_dossier_payload(ticker, source_mode=source_mode)
+    except Exception:  # pragma: no cover - legacy endpoints should survive missing dossier state
+        return None
+
+
+def _canonical_payload_from_dossier(dossier_payload: dict[str, Any], adapter_name: str) -> dict[str, Any]:
+    from src.stage_04_pipeline import ticker_dossier as dossier_adapters
+
+    adapter = getattr(dossier_adapters, adapter_name)
+    return dict(adapter(dossier_payload))
+
+
+def _prefer_keys_from(source: dict[str, Any], target: dict[str, Any], keys: list[str]) -> None:
+    for key in keys:
+        if key in source:
+            target[key] = source.get(key)
 
 
 def list_saved_exports(*, ticker: str | None = None, scope: str | None = None, limit: int = 25) -> list[dict[str, Any]]:
@@ -480,8 +511,10 @@ def _valuation_payload(snapshot: dict[str, Any] | None) -> dict[str, Any]:
     return dict(valuation) if isinstance(valuation, dict) else {}
 
 
-def build_ticker_workspace_payload(ticker: str) -> dict[str, Any]:
+def build_ticker_workspace_payload(ticker: str, dossier_payload: dict[str, Any] | None | object = _DOSSIER_NOT_PROVIDED) -> dict[str, Any]:
     ticker = _coerce_ticker(ticker)
+    if dossier_payload is _DOSSIER_NOT_PROVIDED:
+        dossier_payload = _load_api_ticker_dossier_payload(ticker)
     watchlist_row = _watchlist_row_for_ticker(ticker)
     snapshot = _snapshot_payload(ticker)
     memo = _memo_payload(snapshot)
@@ -554,12 +587,41 @@ def build_ticker_workspace_payload(ticker: str) -> dict[str, Any]:
             watchlist_row.get("latest_conviction"),
         ),
     }
-    return _attach_api_ticker_dossier(payload, ticker)
+    if isinstance(dossier_payload, dict):
+        try:
+            canonical = _canonical_payload_from_dossier(dossier_payload, "workspace_payload_from_dossier")
+        except Exception:
+            canonical = {}
+        _prefer_keys_from(
+            canonical,
+            payload,
+            [
+                "ticker",
+                "company_name",
+                "sector",
+                "current_price",
+                "base_iv",
+                "bear_iv",
+                "bull_iv",
+                "weighted_iv",
+                "upside_pct_base",
+                "analyst_target",
+                "analyst_recommendation",
+                "latest_snapshot_date",
+                "snapshot_available",
+                "last_snapshot_id",
+                "snapshot_id",
+                "last_snapshot_date",
+                "ticker_dossier_contract_version",
+            ],
+        )
+    return _attach_api_ticker_dossier(payload, ticker, dossier_payload=dossier_payload)
 
 
 def build_overview_payload(ticker: str) -> dict[str, Any]:
     ticker = _coerce_ticker(ticker)
-    workspace = build_ticker_workspace_payload(ticker)
+    dossier_payload = _load_api_ticker_dossier_payload(ticker)
+    workspace = build_ticker_workspace_payload(ticker, dossier_payload=dossier_payload)
     snapshot = _snapshot_payload(ticker)
     memo = _memo_payload(snapshot)
     tracker = build_thesis_tracker_view(ticker)
@@ -585,7 +647,14 @@ def build_overview_payload(ticker: str) -> dict[str, Any]:
         "next_catalyst": next_catalyst,
         "workspace": workspace,
     }
-    return _attach_api_ticker_dossier(payload, ticker)
+    if isinstance(dossier_payload, dict):
+        try:
+            canonical = _canonical_payload_from_dossier(dossier_payload, "overview_payload_from_dossier")
+        except Exception:
+            canonical = {}
+        _prefer_keys_from(canonical, payload, ["ticker", "company_name", "valuation_pulse", "ticker_dossier_contract_version"])
+        payload["workspace"] = workspace
+    return _attach_api_ticker_dossier(payload, ticker, dossier_payload=dossier_payload)
 
 
 build_ticker_overview_payload = build_overview_payload
@@ -593,6 +662,7 @@ build_ticker_overview_payload = build_overview_payload
 
 def build_valuation_summary_payload(ticker: str) -> dict[str, Any]:
     ticker = _coerce_ticker(ticker)
+    dossier_payload = _load_api_ticker_dossier_payload(ticker)
     watchlist_row = _watchlist_row_for_ticker(ticker)
     snapshot = _snapshot_payload(ticker)
     memo = _memo_payload(snapshot)
@@ -631,7 +701,29 @@ def build_valuation_summary_payload(ticker: str) -> dict[str, Any]:
         "readiness": summary.get("model_integrity") or {},
         "summary": summary,
     }
-    return _attach_api_ticker_dossier(payload, ticker)
+    if isinstance(dossier_payload, dict):
+        try:
+            canonical = _canonical_payload_from_dossier(dossier_payload, "valuation_summary_payload_from_dossier")
+        except Exception:
+            canonical = {}
+        _prefer_keys_from(
+            canonical,
+            payload,
+            [
+                "ticker",
+                "current_price",
+                "base_iv",
+                "bear_iv",
+                "bull_iv",
+                "weighted_iv",
+                "upside_pct_base",
+                "analyst_target",
+                "memo_date",
+                "why_it_matters",
+                "ticker_dossier_contract_version",
+            ],
+        )
+    return _attach_api_ticker_dossier(payload, ticker, dossier_payload=dossier_payload)
 
 
 def build_valuation_dcf_payload(ticker: str) -> dict[str, Any]:

--- a/docs/design-docs/ticker-dossier-contract.md
+++ b/docs/design-docs/ticker-dossier-contract.md
@@ -104,6 +104,8 @@ This mapping describes the current surfaces that should point at the contract.
 
 API, React, and export flows should point at this contract, not at ad hoc per-surface reshaping. Runtime migrations should keep legacy response fields stable and add or derive from the canonical envelope until downstream callers have fully moved over.
 
+The issue #22 consumer-alignment tranche keeps that additive migration model. API workspace, overview, valuation summary, React preload normalization, and HTML export context now read canonical-owned company, market, valuation, source-mode, and snapshot metadata from `ticker_dossier.latest_snapshot` through adapter-level helpers. Legacy roots remain compatibility shims for PM action, conviction, human memo text, tracker lines, market narrative, readiness, full DCF audit summaries, workbook JSON roots, and existing export templates.
+
 ## Current Runtime Compatibility Roots
 
 The first runtime adapter keeps the existing Excel/HTML export roots for compatibility and adds the canonical `ticker_dossier` envelope beside them. Until downstream templates and clients fully migrate, the legacy-compatible staged JSON roots below remain part of the export payload.
@@ -163,7 +165,7 @@ Rules for producers:
 ```json
 {
   "latest_snapshot": {
-    "identity": {
+    "company_identity": {
       "ticker": "IBM",
       "display_name": "International Business Machines",
       "sector": "Technology",

--- a/docs/plans/future/2026-04-02-epic-canonical-ticker-dossier-and-export-integrity.md
+++ b/docs/plans/future/2026-04-02-epic-canonical-ticker-dossier-and-export-integrity.md
@@ -6,7 +6,7 @@
 | Priority | P0 |
 | Target release | v0.2.0 Dossier Integrity |
 | GitHub | [#14](https://github.com/smrik/ai-fund/issues/14) |
-| Last updated | 2026-05-04 |
+| Last updated | 2026-05-05 |
 
 ## Problem
 
@@ -51,3 +51,5 @@ One canonical ticker dossier contract can feed API responses, React pages, and E
 ## Notes
 
 This is the first roadmap epic because every later product surface becomes easier once the ticker dossier is reliable.
+
+Issue #22 aligns API, React preload, and HTML export consumers through canonical `ticker_dossier` adapter reads while keeping legacy API fields, workbook JSON roots, and export templates stable as compatibility shims.

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -23,6 +23,11 @@ import type {
   WaccPayload,
   WaccPreviewPayload,
 } from "@/lib/types";
+import {
+  normalizeOverviewPayload,
+  normalizeTickerWorkspace,
+  normalizeValuationSummaryPayload,
+} from "@/lib/canonical";
 
 const API_BASE = (import.meta.env.VITE_API_BASE as string | undefined) ?? "/api";
 
@@ -63,15 +68,17 @@ export function getRunStatus(runId: string): Promise<RunPayload> {
 }
 
 export function getTickerWorkspace(ticker: string): Promise<TickerWorkspace> {
-  return requestJSON<TickerWorkspace>(`/tickers/${encodeURIComponent(ticker)}/workspace`);
+  return requestJSON<TickerWorkspace>(`/tickers/${encodeURIComponent(ticker)}/workspace`).then(normalizeTickerWorkspace);
 }
 
 export function getOverview(ticker: string): Promise<OverviewPayload> {
-  return requestJSON<OverviewPayload>(`/tickers/${encodeURIComponent(ticker)}/overview`);
+  return requestJSON<OverviewPayload>(`/tickers/${encodeURIComponent(ticker)}/overview`).then(normalizeOverviewPayload);
 }
 
 export function getValuationSummary(ticker: string): Promise<ValuationSummaryPayload> {
-  return requestJSON<ValuationSummaryPayload>(`/tickers/${encodeURIComponent(ticker)}/valuation/summary`);
+  return requestJSON<ValuationSummaryPayload>(`/tickers/${encodeURIComponent(ticker)}/valuation/summary`).then(
+    normalizeValuationSummaryPayload,
+  );
 }
 
 export function getValuationDcf(ticker: string): Promise<ValuationDcfPayload> {

--- a/frontend/src/lib/canonical.ts
+++ b/frontend/src/lib/canonical.ts
@@ -1,0 +1,109 @@
+import type {
+  ArchivedSnapshotPayload,
+  OverviewPayload,
+  TickerDossierPayload,
+  TickerWorkspace,
+  ValuationSummaryPayload,
+} from "@/lib/types";
+
+function percentPoints(value: number | null | undefined): number | null {
+  if (value == null) {
+    return null;
+  }
+  return value >= -1 && value <= 1 ? value * 100 : value;
+}
+
+function valuationPulse(dossier: TickerDossierPayload): string | null {
+  const valuation = dossier.latest_snapshot.valuation_snapshot;
+  const market = dossier.latest_snapshot.market_snapshot;
+  const currentPrice = market.price ?? valuation.current_price ?? null;
+  if (valuation.base_iv == null || currentPrice == null) {
+    return null;
+  }
+  return `Base IV $${valuation.base_iv.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })} versus current price $${currentPrice.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}.`;
+}
+
+export function normalizeTickerWorkspace(payload: TickerWorkspace): TickerWorkspace {
+  const dossier = payload.ticker_dossier;
+  if (!dossier) {
+    return payload;
+  }
+  const latest = dossier.latest_snapshot;
+  const identity = latest.company_identity;
+  const market = latest.market_snapshot;
+  const valuation = latest.valuation_snapshot;
+  const snapshotId = dossier.export_metadata.snapshot_id ?? payload.last_snapshot_id ?? payload.snapshot_id ?? null;
+
+  return {
+    ...payload,
+    ticker: dossier.ticker,
+    company_name: dossier.display_name ?? identity.display_name,
+    sector: identity.sector ?? null,
+    current_price: market.price ?? valuation.current_price ?? null,
+    analyst_target: market.analyst_target ?? null,
+    bear_iv: valuation.bear_iv ?? null,
+    base_iv: valuation.base_iv ?? null,
+    bull_iv: valuation.bull_iv ?? null,
+    weighted_iv: valuation.expected_iv ?? null,
+    upside_pct_base: valuation.upside_pct ?? null,
+    latest_snapshot_date: dossier.as_of_date,
+    snapshot_available: snapshotId != null,
+    last_snapshot_id: snapshotId,
+    snapshot_id: snapshotId,
+    ticker_dossier_contract_version: dossier.contract_version,
+    ticker_dossier: dossier,
+  };
+}
+
+export function normalizeOverviewPayload(payload: OverviewPayload): OverviewPayload {
+  const dossier = payload.ticker_dossier;
+  if (!dossier) {
+    return payload;
+  }
+  const identity = dossier.latest_snapshot.company_identity;
+  const canonicalPulse = valuationPulse(dossier);
+  return {
+    ...payload,
+    ticker: dossier.ticker,
+    company_name: dossier.display_name ?? identity.display_name,
+    valuation_pulse: canonicalPulse ?? payload.valuation_pulse ?? null,
+    workspace: payload.workspace ? normalizeTickerWorkspace(payload.workspace) : payload.workspace,
+    ticker_dossier_contract_version: dossier.contract_version,
+    ticker_dossier: dossier,
+  };
+}
+
+export function normalizeValuationSummaryPayload(payload: ValuationSummaryPayload): ValuationSummaryPayload {
+  const dossier = payload.ticker_dossier;
+  if (!dossier) {
+    return payload;
+  }
+  const market = dossier.latest_snapshot.market_snapshot;
+  const valuation = dossier.latest_snapshot.valuation_snapshot;
+  const currentPrice = market.price ?? valuation.current_price ?? null;
+  return {
+    ...payload,
+    ticker: dossier.ticker,
+    current_price: currentPrice,
+    base_iv: valuation.base_iv ?? null,
+    bear_iv: valuation.bear_iv ?? null,
+    bull_iv: valuation.bull_iv ?? null,
+    weighted_iv: valuation.expected_iv ?? null,
+    upside_pct_base: percentPoints(valuation.upside_pct),
+    analyst_target: market.analyst_target ?? null,
+    memo_date: dossier.as_of_date,
+    why_it_matters: valuationPulse(dossier) ?? payload.why_it_matters ?? null,
+    ticker_dossier_contract_version: dossier.contract_version,
+    ticker_dossier: dossier,
+  };
+}
+
+export function snapshotDossier(snapshot: ArchivedSnapshotPayload): TickerDossierPayload | undefined {
+  return snapshot.ticker_dossier;
+}

--- a/frontend/src/lib/snapshot.ts
+++ b/frontend/src/lib/snapshot.ts
@@ -1,4 +1,5 @@
 import type { ArchivedSnapshotPayload, OverviewPayload, TickerWorkspace } from "@/lib/types";
+import { normalizeOverviewPayload, normalizeTickerWorkspace, snapshotDossier } from "@/lib/canonical";
 
 export function snapshotToWorkspace(
   snapshot: ArchivedSnapshotPayload,
@@ -6,33 +7,30 @@ export function snapshotToWorkspace(
 ): TickerWorkspace {
   const memo = snapshot.memo ?? {};
   const valuation = memo.valuation ?? {};
-  const dossier = snapshot.ticker_dossier;
-  const latest = dossier?.latest_snapshot;
-  const identity = latest?.company_identity;
-  const market = latest?.market_snapshot;
-  const dossierValuation = latest?.valuation_snapshot;
+  const dossier = snapshotDossier(snapshot);
 
-  return {
-    ticker: dossier?.ticker ?? snapshot.ticker,
-    company_name: dossier?.display_name ?? identity?.display_name ?? snapshot.company_name ?? memo.company_name ?? previous?.company_name ?? snapshot.ticker,
-    sector: identity?.sector ?? snapshot.sector ?? memo.sector ?? previous?.sector ?? null,
+  return normalizeTickerWorkspace({
+    ticker: snapshot.ticker,
+    company_name: snapshot.company_name ?? memo.company_name ?? previous?.company_name ?? snapshot.ticker,
+    sector: snapshot.sector ?? memo.sector ?? previous?.sector ?? null,
     action: snapshot.action ?? memo.action ?? previous?.action ?? null,
     conviction: snapshot.conviction ?? memo.conviction ?? previous?.conviction ?? null,
-    current_price: market?.price ?? dossierValuation?.current_price ?? snapshot.current_price ?? valuation.current_price ?? previous?.current_price ?? null,
-    analyst_target: market?.analyst_target ?? previous?.analyst_target ?? null,
-    bear_iv: dossierValuation?.bear_iv ?? valuation.bear ?? previous?.bear_iv ?? null,
-    base_iv: dossierValuation?.base_iv ?? snapshot.base_iv ?? valuation.base ?? previous?.base_iv ?? null,
-    bull_iv: dossierValuation?.bull_iv ?? valuation.bull ?? previous?.bull_iv ?? null,
-    weighted_iv: dossierValuation?.expected_iv ?? previous?.weighted_iv ?? null,
-    upside_pct_base: dossierValuation?.upside_pct ?? valuation.upside_pct_base ?? previous?.upside_pct_base ?? null,
-    latest_snapshot_date: dossier?.as_of_date ?? snapshot.created_at ?? previous?.latest_snapshot_date ?? null,
+    current_price: snapshot.current_price ?? valuation.current_price ?? previous?.current_price ?? null,
+    analyst_target: previous?.analyst_target ?? null,
+    bear_iv: valuation.bear ?? previous?.bear_iv ?? null,
+    base_iv: snapshot.base_iv ?? valuation.base ?? previous?.base_iv ?? null,
+    bull_iv: valuation.bull ?? previous?.bull_iv ?? null,
+    weighted_iv: previous?.weighted_iv ?? null,
+    upside_pct_base: valuation.upside_pct_base ?? previous?.upside_pct_base ?? null,
+    latest_snapshot_date: snapshot.created_at ?? previous?.latest_snapshot_date ?? null,
     snapshot_available: true,
-    last_snapshot_id: dossier?.export_metadata.snapshot_id ?? snapshot.id,
+    last_snapshot_id: snapshot.id,
+    snapshot_id: snapshot.id,
     latest_action: snapshot.action ?? memo.action ?? previous?.latest_action ?? null,
     latest_conviction: snapshot.conviction ?? memo.conviction ?? previous?.latest_conviction ?? null,
-    ticker_dossier_contract_version: dossier?.contract_version ?? previous?.ticker_dossier_contract_version ?? null,
+    ticker_dossier_contract_version: previous?.ticker_dossier_contract_version ?? null,
     ticker_dossier: dossier ?? previous?.ticker_dossier,
-  };
+  });
 }
 
 export function snapshotToOverview(
@@ -40,19 +38,18 @@ export function snapshotToOverview(
   previous?: OverviewPayload,
 ): OverviewPayload {
   const memo = snapshot.memo ?? {};
-  const dossier = snapshot.ticker_dossier;
-  const identity = dossier?.latest_snapshot.company_identity;
+  const dossier = snapshotDossier(snapshot);
 
-  return {
-    ticker: dossier?.ticker ?? snapshot.ticker,
-    company_name: dossier?.display_name ?? identity?.display_name ?? snapshot.company_name ?? memo.company_name ?? previous?.company_name ?? snapshot.ticker,
+  return normalizeOverviewPayload({
+    ticker: snapshot.ticker,
+    company_name: snapshot.company_name ?? memo.company_name ?? previous?.company_name ?? snapshot.ticker,
     one_liner: memo.one_liner ?? previous?.one_liner ?? null,
     variant_thesis_prompt: memo.variant_thesis_prompt ?? previous?.variant_thesis_prompt ?? null,
     market_pulse: previous?.market_pulse ?? null,
     valuation_pulse: previous?.valuation_pulse ?? null,
     thesis_changes: previous?.thesis_changes ?? [],
     next_catalyst: previous?.next_catalyst ?? null,
-    ticker_dossier_contract_version: dossier?.contract_version ?? previous?.ticker_dossier_contract_version ?? null,
+    ticker_dossier_contract_version: previous?.ticker_dossier_contract_version ?? null,
     ticker_dossier: dossier ?? previous?.ticker_dossier,
-  };
+  });
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -40,6 +40,7 @@ export interface TickerWorkspace {
   upside_pct_base: number | null;
   latest_snapshot_date: string | null;
   snapshot_available: boolean;
+  snapshot_id?: number | null;
   last_snapshot_id?: number | null;
   latest_action?: string | null;
   latest_conviction?: string | null;
@@ -56,6 +57,7 @@ export interface OverviewPayload {
   valuation_pulse?: string | null;
   thesis_changes?: string[];
   next_catalyst?: string | null;
+  workspace?: TickerWorkspace;
   ticker_dossier_contract_version?: string | null;
   ticker_dossier?: TickerDossierPayload;
 }
@@ -154,6 +156,8 @@ export interface ValuationSummaryPayload {
   why_it_matters?: string | null;
   readiness?: Record<string, unknown> | null;
   summary?: Record<string, unknown> | null;
+  ticker_dossier_contract_version?: string | null;
+  ticker_dossier?: TickerDossierPayload;
 }
 
 export interface AssumptionsPayload {

--- a/frontend/src/test/appRoutes.test.tsx
+++ b/frontend/src/test/appRoutes.test.tsx
@@ -30,6 +30,42 @@ const watchlistPayload = {
   default_focus_ticker: "IBM",
 };
 
+const canonicalDossier = {
+  contract_name: "TickerDossier",
+  contract_version: "1.0.0",
+  ticker: "IBM",
+  as_of_date: "2026-04-30",
+  display_name: "Canonical Machines",
+  currency: "USD",
+  latest_snapshot: {
+    company_identity: {
+      ticker: "IBM",
+      display_name: "Canonical Machines",
+      sector: "Canonical Sector",
+      industry: "Canonical Industry",
+      exchange: "NYSE",
+    },
+    market_snapshot: {
+      as_of_date: "2026-04-30",
+      price: 111,
+      analyst_target: 222,
+      analyst_recommendation: "canonical-rating",
+    },
+    valuation_snapshot: {
+      bear_iv: 120,
+      base_iv: 155,
+      bull_iv: 210,
+      expected_iv: 166,
+      current_price: 112,
+      upside_pct: 0.35,
+    },
+  },
+  loaded_backend_state: { backend_name: "test", source_mode: "latest_snapshot" },
+  source_lineage: {},
+  export_metadata: { source_mode: "latest_snapshot", snapshot_id: 44 },
+  optional_overlays: {},
+} as const;
+
 const workspacePayload = {
   ticker: "IBM",
   company_name: "IBM",
@@ -41,6 +77,8 @@ const workspacePayload = {
   upside_pct_base: 0.2,
   latest_snapshot_date: "2026-03-28",
   snapshot_available: true,
+  ticker_dossier: canonicalDossier,
+  ticker_dossier_contract_version: "1.0.0",
 };
 
 beforeEach(() => {
@@ -65,6 +103,8 @@ beforeEach(() => {
             one_liner: "Memo",
             variant_thesis_prompt: "Question?",
             thesis_changes: ["Moved to watchlist-first IA"],
+            ticker_dossier: canonicalDossier,
+            ticker_dossier_contract_version: "1.0.0",
           }),
           { status: 200 },
         );
@@ -85,6 +125,8 @@ beforeEach(() => {
             memo_date: "2026-03-28",
             why_it_matters: "Base case still implies upside with a controlled terminal value contribution.",
             readiness: { tv_high_flag: false, revenue_data_quality_flag: "company", nwc_driver_quality_flag: false },
+            ticker_dossier: canonicalDossier,
+            ticker_dossier_contract_version: "1.0.0",
           }),
           { status: 200 },
         );
@@ -595,8 +637,10 @@ describe("frontend routes", () => {
   it("renders a shared ticker nav and a consistent overview hero", async () => {
     renderRoute("/ticker/IBM/overview");
 
-    expect(await screen.findByRole("heading", { name: "IBM" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Canonical Machines" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "IBM" })).toBeInTheDocument();
+    expect(screen.getByText("$155.00")).toBeInTheDocument();
+    expect(screen.getByText("+35.0%")).toBeInTheDocument();
     expect(screen.getByText("Variant Thesis")).toBeInTheDocument();
     expect(screen.getByText("Latest Snapshot")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Open Latest Snapshot" })).toBeInTheDocument();
@@ -606,7 +650,9 @@ describe("frontend routes", () => {
   it("shows valuation sub-navigation including assumptions and wacc", async () => {
     renderRoute("/ticker/IBM/valuation?view=Assumptions");
 
-    expect(await screen.findByRole("heading", { name: "IBM" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Canonical Machines" })).toBeInTheDocument();
+    expect(screen.getByText("$111.00")).toBeInTheDocument();
+    expect(screen.getAllByText("$155.00").length).toBeGreaterThan(0);
     expect(screen.getByRole("button", { name: "Assumptions" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "WACC" })).toBeInTheDocument();
   });
@@ -688,7 +734,7 @@ describe("frontend routes", () => {
 
     renderRoute("/ticker/IBM/valuation?view=Assumptions");
 
-    expect(await screen.findByRole("heading", { name: "IBM" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Canonical Machines" })).toBeInTheDocument();
     await waitFor(() => expect(hits.assumptions).toBeGreaterThan(0));
     expect(hits.summary).toBe(0);
     expect(hits.dcf).toBe(0);
@@ -708,7 +754,7 @@ describe("frontend routes", () => {
 
     renderRoute("/ticker/IBM/valuation?view=WACC");
 
-    expect(await screen.findByRole("heading", { name: "IBM" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Canonical Machines" })).toBeInTheDocument();
     await waitFor(() => expect(hits.wacc).toBeGreaterThan(0));
     expect(hits.summary).toBe(0);
     expect(hits.dcf).toBe(0);
@@ -726,7 +772,7 @@ describe("frontend routes", () => {
     hits.waccPreview = 0;
     hits.recommendations = 0;
     renderRoute("/ticker/IBM/valuation?view=Comparables");
-    expect(await screen.findByRole("heading", { name: "IBM" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Canonical Machines" })).toBeInTheDocument();
     await waitFor(() => expect(hits.comps).toBeGreaterThan(0));
     expect(hits.summary).toBe(0);
     expect(hits.dcf).toBe(0);
@@ -743,7 +789,7 @@ describe("frontend routes", () => {
     hits.waccPreview = 0;
     hits.recommendations = 0;
     renderRoute("/ticker/IBM/valuation?view=Multiples");
-    expect(await screen.findByRole("heading", { name: "IBM" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Canonical Machines" })).toBeInTheDocument();
     await waitFor(() => expect(hits.comps).toBeGreaterThan(0));
 
     cleanup();
@@ -758,7 +804,7 @@ describe("frontend routes", () => {
     hits.waccPreview = 0;
     hits.recommendations = 0;
     renderRoute("/ticker/IBM/valuation?view=Recommendations");
-    expect(await screen.findByRole("heading", { name: "IBM" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Canonical Machines" })).toBeInTheDocument();
     await waitFor(() => expect(hits.recommendations).toBeGreaterThan(0));
     expect(hits.summary).toBe(0);
     expect(hits.comps).toBe(0);
@@ -767,7 +813,7 @@ describe("frontend routes", () => {
   it("keeps ticker navigation shared and valuation sub-navigation local to the page", async () => {
     const { container } = renderRoute("/ticker/IBM/valuation?view=Summary");
 
-    expect(await screen.findByRole("heading", { name: "IBM" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Canonical Machines" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Open Latest Snapshot" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Run Deep Analysis" })).toBeInTheDocument();
     expect(container.querySelector(".ticker-strip")).not.toBeInTheDocument();
@@ -921,7 +967,7 @@ describe("frontend routes", () => {
 
   it("renders the other ticker surfaces without blowing up the route shell", async () => {
     const { container: marketContainer } = renderRoute("/ticker/IBM/market");
-    expect(await screen.findByRole("heading", { name: "IBM" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Canonical Machines" })).toBeInTheDocument();
     expect(await screen.findByRole("button", { name: "News & Revisions" })).toBeInTheDocument();
     expect(await screen.findByText("Recommendation")).toBeInTheDocument();
     expect(await screen.findByText("Historical Timeline")).toBeInTheDocument();
@@ -943,7 +989,7 @@ describe("frontend routes", () => {
 
     cleanup();
     renderRoute("/ticker/IBM/research");
-    expect(await screen.findByRole("heading", { name: "IBM" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Canonical Machines" })).toBeInTheDocument();
     expect(await screen.findByText("Cost discipline improved, but acquisition execution still needs proof.")).toBeInTheDocument();
     expect(await screen.findByText("Draft memo available (7 sections: Summary, Business, Thesis, Valuation, Risks, Catalysts, Sources).")).toBeInTheDocument();
     expect(await screen.findByText("WATCH")).toBeInTheDocument();
@@ -958,7 +1004,7 @@ describe("frontend routes", () => {
 
     cleanup();
     renderRoute("/ticker/IBM/audit");
-    expect(await screen.findByRole("heading", { name: "IBM" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Canonical Machines" })).toBeInTheDocument();
     expect(await screen.findByText("DCF Integrity")).toBeInTheDocument();
     expect(await screen.findByText("Filings Coverage")).toBeInTheDocument();
     expect(await screen.findByText("Historical Multiples Audit")).toBeInTheDocument();

--- a/frontend/src/test/exportFlows.test.tsx
+++ b/frontend/src/test/exportFlows.test.tsx
@@ -31,6 +31,39 @@ const watchlistPayload = {
   default_focus_ticker: "IBM",
 };
 
+const canonicalDossier = {
+  contract_name: "TickerDossier",
+  contract_version: "1.0.0",
+  ticker: "IBM",
+  as_of_date: "2026-04-30",
+  display_name: "Canonical Machines",
+  currency: "USD",
+  latest_snapshot: {
+    company_identity: {
+      ticker: "IBM",
+      display_name: "Canonical Machines",
+      sector: "Canonical Sector",
+    },
+    market_snapshot: {
+      as_of_date: "2026-04-30",
+      price: 111,
+      analyst_target: 222,
+    },
+    valuation_snapshot: {
+      bear_iv: 120,
+      base_iv: 155,
+      bull_iv: 210,
+      expected_iv: 166,
+      current_price: 112,
+      upside_pct: 0.35,
+    },
+  },
+  loaded_backend_state: { backend_name: "test", source_mode: "latest_snapshot" },
+  source_lineage: {},
+  export_metadata: { source_mode: "latest_snapshot", snapshot_id: 44 },
+  optional_overlays: {},
+} as const;
+
 const workspacePayload = {
   ticker: "IBM",
   company_name: "IBM",
@@ -42,6 +75,8 @@ const workspacePayload = {
   upside_pct_base: 0.2,
   latest_snapshot_date: "2026-03-28",
   snapshot_available: true,
+  ticker_dossier: canonicalDossier,
+  ticker_dossier_contract_version: "1.0.0",
 };
 
 function renderRoute(path: string) {
@@ -134,7 +169,7 @@ describe("export flows", () => {
 
     renderRoute("/ticker/IBM/audit");
 
-    expect(await screen.findByRole("heading", { name: "IBM" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Canonical Machines" })).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Exports" }));
     expect(await screen.findByText("Recent Exports")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Export HTML Memo" }));
@@ -167,7 +202,15 @@ describe("export flows", () => {
           return buildResponse(workspacePayload);
         }
         if (url.endsWith("/api/tickers/IBM/valuation/summary")) {
-          return buildResponse({ ticker: "IBM", current_price: 100, base_iv: 120, upside_pct_base: 20, analyst_target: 140 });
+          return buildResponse({
+            ticker: "IBM",
+            current_price: 100,
+            base_iv: 120,
+            upside_pct_base: 20,
+            analyst_target: 140,
+            ticker_dossier: canonicalDossier,
+            ticker_dossier_contract_version: "1.0.0",
+          });
         }
         if (url.endsWith("/api/tickers/IBM/research")) {
           return buildResponse({
@@ -198,7 +241,8 @@ describe("export flows", () => {
     );
 
     renderRoute("/ticker/IBM/valuation");
-    expect(await screen.findByRole("heading", { name: "IBM" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Canonical Machines" })).toBeInTheDocument();
+    expect(screen.getAllByText("$155.00").length).toBeGreaterThan(0);
     fireEvent.click(screen.getByRole("button", { name: "Export Excel" }));
 
     await waitFor(() =>
@@ -216,7 +260,7 @@ describe("export flows", () => {
     queryClient.clear();
 
     renderRoute("/ticker/IBM/research");
-    expect(await screen.findByRole("heading", { name: "IBM" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Canonical Machines" })).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Export HTML Memo" }));
 
     await waitFor(() =>

--- a/src/stage_04_pipeline/export_service.py
+++ b/src/stage_04_pipeline/export_service.py
@@ -146,6 +146,51 @@ def _persist_attached_ticker_dossier(payload: dict[str, Any]) -> None:
     upsert_ticker_dossier_snapshot(dossier_payload, connection_factory=get_connection)
 
 
+def _html_context_scalars_from_dossier(payload: dict[str, Any]) -> dict[str, Any]:
+    dossier = payload.get("ticker_dossier")
+    if not isinstance(dossier, dict):
+        return {}
+    latest = dossier.get("latest_snapshot") if isinstance(dossier.get("latest_snapshot"), dict) else {}
+    identity = latest.get("company_identity") if isinstance(latest.get("company_identity"), dict) else {}
+    market = latest.get("market_snapshot") if isinstance(latest.get("market_snapshot"), dict) else {}
+    valuation = latest.get("valuation_snapshot") if isinstance(latest.get("valuation_snapshot"), dict) else {}
+    metadata = dossier.get("export_metadata") if isinstance(dossier.get("export_metadata"), dict) else {}
+    current_price = market.get("price")
+    if current_price is None:
+        current_price = valuation.get("current_price")
+    return {
+        "ticker": dossier.get("ticker"),
+        "company_name": dossier.get("display_name") or identity.get("display_name"),
+        "source_mode": metadata.get("source_mode"),
+        "current_price": current_price,
+        "base_iv": valuation.get("base_iv"),
+        "expected_iv": valuation.get("expected_iv"),
+        "as_of_date": dossier.get("as_of_date"),
+        "snapshot_id": metadata.get("snapshot_id"),
+        "ticker_dossier_contract_version": dossier.get("contract_version"),
+        "ticker_dossier": dossier,
+    }
+
+
+def _apply_html_context_scalars(context: dict[str, Any], payload: dict[str, Any]) -> dict[str, Any]:
+    scalars = _html_context_scalars_from_dossier(payload)
+    for key, value in scalars.items():
+        if value is not None:
+            context[key] = value
+
+    valuation = dict(context.get("valuation") or {})
+    for context_key, valuation_key in (
+        ("current_price", "current_price"),
+        ("base_iv", "iv_base"),
+        ("expected_iv", "expected_iv"),
+    ):
+        value = scalars.get(context_key)
+        if value is not None:
+            valuation[valuation_key] = value
+    context["valuation"] = valuation
+    return context
+
+
 def _clear_sheet(ws) -> None:
     for merged_range in list(ws.merged_cells.ranges):
         ws.unmerge_cells(str(merged_range))
@@ -914,7 +959,7 @@ def _build_html_context(ticker: str, source_mode: str) -> tuple[dict[str, Any], 
         payload, snapshot_id = _build_snapshot_ticker_payload(ticker)
         memo = payload.get("snapshot", {}).get("memo") or {}
         publishable = build_publishable_memo_context(ticker)
-        return (
+        context = _apply_html_context_scalars(
             {
                 "ticker": ticker,
                 "company_name": payload.get("company_name"),
@@ -927,12 +972,13 @@ def _build_html_context(ticker: str, source_mode: str) -> tuple[dict[str, Any], 
                 "artifacts": publishable.get("artifacts") or [],
                 "ticker_dossier": payload.get("ticker_dossier"),
             },
-            snapshot_id,
+            payload,
         )
+        return (context, snapshot_id)
     payload = _build_current_ticker_payload(ticker)
     publishable = build_publishable_memo_context(ticker)
     research = payload.get("research") or {}
-    return (
+    context = _apply_html_context_scalars(
         {
             "ticker": ticker,
             "company_name": payload.get("company_name"),
@@ -945,8 +991,9 @@ def _build_html_context(ticker: str, source_mode: str) -> tuple[dict[str, Any], 
             "artifacts": publishable.get("artifacts") or [],
             "ticker_dossier": payload.get("ticker_dossier"),
         },
-        None,
+        payload,
     )
+    return (context, None)
 
 
 def _ticker_bundle_dir(ticker: str, export_format: str) -> Path:

--- a/src/stage_04_pipeline/ticker_dossier.py
+++ b/src/stage_04_pipeline/ticker_dossier.py
@@ -68,6 +68,15 @@ def _as_int(value: Any) -> int | None:
     return None
 
 
+def _as_percent_points(value: Any) -> float | None:
+    value = _as_float(value)
+    if value is None:
+        return None
+    if -1.0 <= value <= 1.0:
+        return value * 100.0
+    return value
+
+
 def _scenario_probability_map(scenarios: dict[str, Any]) -> dict[str, float | None]:
     return {
         key: _as_float((value or {}).get("probability"))
@@ -379,7 +388,7 @@ def workspace_payload_from_dossier(dossier: TickerDossier | dict[str, Any]) -> d
         "ticker": dossier.ticker,
         "company_name": dossier.display_name,
         "sector": snapshot.company_identity.sector,
-        "action": market.analyst_recommendation,
+        "action": None,
         "conviction": None,
         "current_price": current_price,
         "base_iv": valuation.base_iv,
@@ -394,7 +403,7 @@ def workspace_payload_from_dossier(dossier: TickerDossier | dict[str, Any]) -> d
         "last_snapshot_id": dossier.export_metadata.snapshot_id,
         "snapshot_id": dossier.export_metadata.snapshot_id,
         "last_snapshot_date": dossier.as_of_date,
-        "latest_action": market.analyst_recommendation,
+        "latest_action": None,
         "latest_conviction": None,
         "ticker_dossier_contract_version": TICKER_DOSSIER_CONTRACT_VERSION,
     }
@@ -405,7 +414,7 @@ def overview_payload_from_dossier(dossier: TickerDossier | dict[str, Any]) -> di
     workspace = workspace_payload_from_dossier(dossier)
     valuation = dossier.latest_snapshot.valuation_snapshot
     valuation_pulse = None
-    current_price = _first_present(valuation.current_price, dossier.latest_snapshot.market_snapshot.price)
+    current_price = _first_present(dossier.latest_snapshot.market_snapshot.price, valuation.current_price)
     if valuation.base_iv is not None and current_price is not None:
         valuation_pulse = f"Base IV ${valuation.base_iv:,.2f} versus current price ${current_price:,.2f}."
     return {
@@ -426,7 +435,7 @@ def valuation_summary_payload_from_dossier(dossier: TickerDossier | dict[str, An
     dossier = TickerDossier.model_validate(dossier)
     valuation = dossier.latest_snapshot.valuation_snapshot
     market = dossier.latest_snapshot.market_snapshot
-    current_price = _first_present(valuation.current_price, market.price)
+    current_price = _first_present(market.price, valuation.current_price)
     why_it_matters = None
     if valuation.base_iv is not None and current_price is not None:
         why_it_matters = f"Base IV ${valuation.base_iv:,.2f} versus current price ${current_price:,.2f}."
@@ -437,7 +446,7 @@ def valuation_summary_payload_from_dossier(dossier: TickerDossier | dict[str, An
         "bear_iv": valuation.bear_iv,
         "bull_iv": valuation.bull_iv,
         "weighted_iv": valuation.expected_iv,
-        "upside_pct_base": valuation.upside_pct,
+        "upside_pct_base": _as_percent_points(valuation.upside_pct),
         "analyst_target": market.analyst_target,
         "conviction": None,
         "memo_date": dossier.as_of_date,

--- a/tests/test_api_contracts.py
+++ b/tests/test_api_contracts.py
@@ -7,6 +7,130 @@ from pathlib import Path
 from fastapi.testclient import TestClient
 
 
+def _canonical_dossier_payload() -> dict:
+    return {
+        "contract_name": "TickerDossier",
+        "contract_version": "1.0.0",
+        "ticker": "IBM",
+        "as_of_date": "2026-04-30",
+        "display_name": "Canonical Machines",
+        "currency": "USD",
+        "latest_snapshot": {
+            "company_identity": {
+                "ticker": "IBM",
+                "display_name": "Canonical Machines",
+                "sector": "Canonical Sector",
+                "industry": "Canonical Industry",
+                "exchange": "NYSE",
+            },
+            "market_snapshot": {
+                "as_of_date": "2026-04-30",
+                "price": 111.0,
+                "analyst_target": 222.0,
+                "analyst_recommendation": "canonical-rating",
+            },
+            "valuation_snapshot": {
+                "bear_iv": 120.0,
+                "base_iv": 155.0,
+                "bull_iv": 210.0,
+                "expected_iv": 166.0,
+                "current_price": 112.0,
+                "upside_pct": 0.35,
+            },
+            "historical_series": {},
+            "qoe_snapshot": {"present": False, "score": None, "flags": []},
+            "comps_snapshot": {},
+            "source_lineage": {},
+        },
+        "loaded_backend_state": {"backend_name": "test", "source_mode": "latest_snapshot"},
+        "source_lineage": {},
+        "export_metadata": {"source_mode": "latest_snapshot", "snapshot_id": 44},
+        "optional_overlays": {},
+    }
+
+
+def _install_legacy_ticker_mocks(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "api.main.load_saved_watchlist",
+        lambda shortlist_size=10: {
+            "rows": [
+                {
+                    "ticker": "IBM",
+                    "company_name": "Legacy Watchlist",
+                    "sector": "Legacy Watchlist Sector",
+                    "price": 10.0,
+                    "iv_bear": 11.0,
+                    "iv_base": 20.0,
+                    "iv_bull": 30.0,
+                    "expected_iv": 22.0,
+                    "upside_base_pct": 100.0,
+                    "latest_action": "BUY",
+                    "latest_conviction": "high",
+                    "latest_snapshot_date": "2026-01-01",
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        "api.main.load_latest_snapshot_for_ticker",
+        lambda ticker: {
+            "id": 7,
+            "ticker": ticker,
+            "company_name": "Legacy Snapshot",
+            "sector": "Legacy Snapshot Sector",
+            "action": "REVIEW",
+            "conviction": "medium",
+            "current_price": 12.0,
+            "base_iv": 24.0,
+            "created_at": "2026-02-02",
+            "memo": {
+                "company_name": "Legacy Memo",
+                "sector": "Legacy Memo Sector",
+                "action": "WATCH",
+                "conviction": "low",
+                "one_liner": "Legacy one-liner.",
+                "variant_thesis_prompt": "Legacy thesis prompt.",
+                "date": "2026-02-03",
+                "valuation": {
+                    "current_price": 13.0,
+                    "base": 25.0,
+                    "bear": 15.0,
+                    "bull": 35.0,
+                    "upside_pct_base": 0.1,
+                },
+            },
+        },
+    )
+    monkeypatch.setattr(
+        "api.main.get_market_data",
+        lambda ticker, use_cache=True: {
+            "name": "Legacy Market",
+            "sector": "Legacy Market Sector",
+            "current_price": 14.0,
+            "analyst_target_mean": 40.0,
+        },
+    )
+    monkeypatch.setattr("api.main.get_analyst_ratings", lambda ticker: {"target_mean": 41.0, "recommendation": "legacy-rating"})
+    monkeypatch.setattr(
+        "api.main.build_thesis_tracker_view",
+        lambda ticker: {
+            "stance": {"next_catalyst": {"title": "Legacy catalyst"}},
+            "what_changed": {"summary_lines": ["Legacy tracker line"]},
+        },
+    )
+    monkeypatch.setattr(
+        "api.main.build_news_materiality_view",
+        lambda ticker: {"historical_brief": {"summary": "Legacy market pulse."}},
+    )
+    monkeypatch.setattr(
+        "api.main.build_dcf_audit_view",
+        lambda ticker: {
+            "model_integrity": {"tv_high_flag": False, "revenue_data_quality_flag": "legacy"},
+            "scenario_summary": [{"scenario": "base", "intrinsic_value": 25.0}],
+        },
+    )
+
+
 def test_api_allows_local_frontend_cors_requests(monkeypatch):
     from api.main import app
 
@@ -278,6 +402,81 @@ def test_ticker_dossier_payload_falls_back_from_snapshot_builder_to_backend_stat
 
     assert payload["export_metadata"]["source_mode"] == "loaded_backend_state"
     assert build_calls == [("IBM", "latest_snapshot"), ("IBM", "loaded_backend_state")]
+
+
+def test_ticker_api_consumers_prefer_canonical_dossier_facts_and_preserve_legacy_fields(monkeypatch):
+    from api.main import build_overview_payload, build_ticker_workspace_payload, build_valuation_summary_payload
+
+    dossier = _canonical_dossier_payload()
+    build_calls: list[tuple[str, str | None]] = []
+
+    def _build_dossier(ticker: str, source_mode: str | None = None) -> dict:
+        build_calls.append((ticker, source_mode))
+        return dossier
+
+    _install_legacy_ticker_mocks(monkeypatch)
+    monkeypatch.setattr("api.main.build_ticker_dossier_payload", _build_dossier)
+
+    workspace = build_ticker_workspace_payload("ibm")
+    overview = build_overview_payload("ibm")
+    summary = build_valuation_summary_payload("ibm")
+
+    assert workspace["company_name"] == "Canonical Machines"
+    assert workspace["sector"] == "Canonical Sector"
+    assert workspace["current_price"] == 111.0
+    assert workspace["base_iv"] == 155.0
+    assert workspace["bear_iv"] == 120.0
+    assert workspace["bull_iv"] == 210.0
+    assert workspace["weighted_iv"] == 166.0
+    assert workspace["upside_pct_base"] == 0.35
+    assert workspace["analyst_target"] == 222.0
+    assert workspace["latest_snapshot_date"] == "2026-04-30"
+    assert workspace["snapshot_id"] == 44
+    assert workspace["action"] == "REVIEW"
+    assert workspace["conviction"] == "medium"
+    assert workspace["ticker_dossier"] is dossier
+    assert workspace["ticker_dossier_contract_version"] == "1.0.0"
+
+    assert overview["company_name"] == "Canonical Machines"
+    assert overview["one_liner"] == "Legacy one-liner."
+    assert overview["variant_thesis_prompt"] == "Legacy thesis prompt."
+    assert overview["market_pulse"] == "Legacy market pulse."
+    assert overview["thesis_changes"] == ["Legacy tracker line"]
+    assert overview["next_catalyst"] == "Legacy catalyst"
+    assert overview["valuation_pulse"] == "Base IV $155.00 versus current price $111.00."
+    assert overview["workspace"]["company_name"] == "Canonical Machines"
+    assert overview["ticker_dossier"] is dossier
+
+    assert summary["current_price"] == 111.0
+    assert summary["base_iv"] == 155.0
+    assert summary["weighted_iv"] == 166.0
+    assert summary["upside_pct_base"] == 35.0
+    assert summary["analyst_target"] == 222.0
+    assert summary["memo_date"] == "2026-04-30"
+    assert summary["why_it_matters"] == "Base IV $155.00 versus current price $111.00."
+    assert summary["conviction"] == "medium"
+    assert summary["readiness"] == {"tv_high_flag": False, "revenue_data_quality_flag": "legacy"}
+    assert summary["summary"]["scenario_summary"][0]["intrinsic_value"] == 25.0
+    assert summary["ticker_dossier"] is dossier
+
+    assert build_calls == [("IBM", None), ("IBM", None), ("IBM", None)]
+
+
+def test_ticker_api_consumers_fall_back_to_legacy_payloads_when_dossier_fails(monkeypatch):
+    from api.main import build_ticker_workspace_payload
+
+    _install_legacy_ticker_mocks(monkeypatch)
+    monkeypatch.setattr("api.main.build_ticker_dossier_payload", lambda ticker, source_mode=None: (_ for _ in ()).throw(RuntimeError("boom")))
+
+    payload = build_ticker_workspace_payload("IBM")
+
+    assert payload["company_name"] == "Legacy Snapshot"
+    assert payload["sector"] == "Legacy Snapshot Sector"
+    assert payload["current_price"] == 12.0
+    assert payload["base_iv"] == 24.0
+    assert payload["action"] == "REVIEW"
+    assert payload["conviction"] == "medium"
+    assert "ticker_dossier" not in payload
 
 
 def test_market_research_audit_and_valuation_action_endpoints_return_existing_helpers(monkeypatch):

--- a/tests/test_export_service.py
+++ b/tests/test_export_service.py
@@ -28,6 +28,39 @@ def _temp_conn_factory(db_path: Path):
     return _factory
 
 
+def _payload_with_attached_dossier(source_mode: str, snapshot_id: int | None = None) -> dict:
+    return {
+        "ticker": "IBM",
+        "company_name": "Legacy Export Name",
+        "source_mode": source_mode,
+        "generated_at": "2026-04-01T00:00:00+00:00",
+        "valuation": {"current_price": 10.0, "iv_base": 20.0, "expected_iv": 30.0},
+        "research": {"publishable_memo_preview": "Legacy research memo."},
+        "snapshot": {"memo": {"one_liner": "Legacy snapshot memo."}},
+        "ticker_dossier": {
+            "contract_name": "TickerDossier",
+            "contract_version": "1.0.0",
+            "ticker": "IBM",
+            "as_of_date": "2026-04-30",
+            "display_name": "Canonical Machines",
+            "currency": "USD",
+            "latest_snapshot": {
+                "company_identity": {"ticker": "IBM", "display_name": "Canonical Machines", "sector": "Canonical Sector"},
+                "market_snapshot": {"as_of_date": "2026-04-30", "price": 111.0},
+                "valuation_snapshot": {"base_iv": 155.0, "expected_iv": 166.0, "current_price": 112.0},
+                "historical_series": {},
+                "qoe_snapshot": {"present": False, "score": None, "flags": []},
+                "comps_snapshot": {},
+                "source_lineage": {},
+            },
+            "loaded_backend_state": {"backend_name": "test", "source_mode": source_mode},
+            "source_lineage": {},
+            "export_metadata": {"source_mode": source_mode, "snapshot_id": snapshot_id},
+            "optional_overlays": {},
+        },
+    }
+
+
 def test_stage_power_query_workbook_copies_template_and_points_json_path(monkeypatch):
     from src.stage_04_pipeline import export_service
 
@@ -199,6 +232,40 @@ def test_build_html_export_bundle_writes_primary_and_sidecar_assets():
     assert context_path.exists()
     assert copied_asset.exists()
     assert {artifact["artifact_key"] for artifact in result["artifacts"]} == {"html_report", "context_json", "public_chart"}
+
+
+def test_build_html_context_prefers_attached_canonical_dossier_for_current_and_snapshot(monkeypatch):
+    from src.stage_04_pipeline import export_service
+
+    monkeypatch.setattr(export_service, "_build_snapshot_ticker_payload", lambda ticker: (_payload_with_attached_dossier("latest_snapshot", 7), 7))
+    monkeypatch.setattr(export_service, "_build_current_ticker_payload", lambda ticker: _payload_with_attached_dossier("loaded_backend_state"))
+    monkeypatch.setattr(
+        export_service,
+        "build_publishable_memo_context",
+        lambda ticker: {"memo_content": "Canonical memo content.", "artifacts": [{"artifact_key": "chart"}]},
+    )
+
+    snapshot_context, snapshot_id = export_service._build_html_context("IBM", "latest_snapshot")
+    current_context, current_snapshot_id = export_service._build_html_context("IBM", "loaded_backend_state")
+
+    for context in (snapshot_context, current_context):
+        assert context["company_name"] == "Canonical Machines"
+        assert context["current_price"] == 111.0
+        assert context["base_iv"] == 155.0
+        assert context["expected_iv"] == 166.0
+        assert context["as_of_date"] == "2026-04-30"
+        assert context["ticker_dossier_contract_version"] == "1.0.0"
+        assert context["valuation"]["current_price"] == 111.0
+        assert context["valuation"]["iv_base"] == 155.0
+        assert context["valuation"]["expected_iv"] == 166.0
+        assert context["summary"] == "Canonical memo content."
+        assert context["ticker_dossier"]["display_name"] == "Canonical Machines"
+
+    assert snapshot_context["source_mode"] == "latest_snapshot"
+    assert snapshot_context["snapshot_id"] == 7
+    assert snapshot_id == 7
+    assert current_context["source_mode"] == "loaded_backend_state"
+    assert current_snapshot_id is None
 
 
 def test_register_export_bundle_persists_export_and_artifacts(monkeypatch):


### PR DESCRIPTION
Closes #22.\n\n## Summary\n- align API workspace, overview, and valuation summary consumers to prefer canonical ticker_dossier company, market, valuation, as-of, and snapshot metadata\n- add React preload normalization for workspace, overview, valuation summary, and opened snapshots\n- align HTML export scalar context to attached ticker_dossier while preserving legacy roots and fields\n- update dossier contract docs, Epic #14 note, and regression tests\n\n## Verification\n- rtk python -m pytest tests/test_api_contracts.py tests/test_export_service.py tests/test_ticker_dossier_contract_runtime.py tests/test_ticker_dossier_contract_docs.py -q\n- rtk npm --prefix frontend run test -- appRoutes.test.tsx exportFlows.test.tsx\n- rtk npm --prefix frontend run build\n- rtk git diff --check\n- rtk python -m mkdocs build --strict\n- PRE_COMMIT_HOME=.pre-commit-cache-run-codex rtk pre-commit run --all-files