### PR TITLE
feat: add operator diagnostics endpoint (#44)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -373,6 +373,11 @@ def create_app() -> FastAPI:
         allow_headers=["*"],
     )
 
+    @app.get("/api/health")
+    def get_health() -> dict[str, Any]:
+        from src.stage_04_pipeline.diagnostics import run_diagnostics
+        return run_diagnostics().as_dict()
+
     @app.get("/api/watchlist")
     def get_watchlist(shortlist_size: int = 10) -> dict[str, Any]:
         return load_saved_watchlist(shortlist_size=shortlist_size)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,9 @@
 markers = [
     "live: marks tests that require network access (yfinance, SEC EDGAR, etc.) — deselect with -m 'not live'",
 ]
+tmp_path_retention_policy = "failed"
+tmp_path_retention_count = 3
+addopts = "--basetemp=.tmp-tests"
 
 [tool.ruff]
 target-version = "py311"

--- a/src/stage_04_pipeline/diagnostics.py
+++ b/src/stage_04_pipeline/diagnostics.py
@@ -1,0 +1,149 @@
+"""
+Operator diagnostics — cheap, offline, deterministic health checks.
+
+Returns a DiagnosticsPayload describing whether key runtime dependencies
+are healthy, degraded, or unavailable. No LLM calls, no live market data,
+no CIQ refresh.
+"""
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+from config import DB_PATH, DOSSIER_ROOT, OUTPUT_DIR, REPORTS_DIR, UNIVERSE_PATH
+
+Status = Literal["ok", "degraded", "unavailable"]
+
+
+@dataclass
+class CheckResult:
+    name: str
+    status: Status
+    message: str
+
+
+@dataclass
+class DiagnosticsPayload:
+    overall: Status
+    checks: list[CheckResult] = field(default_factory=list)
+
+    def as_dict(self) -> dict:
+        return {
+            "overall": self.overall,
+            "checks": [
+                {"name": c.name, "status": c.status, "message": c.message}
+                for c in self.checks
+            ],
+        }
+
+
+def _check_database() -> CheckResult:
+    try:
+        conn = sqlite3.connect(str(DB_PATH), timeout=2)
+        tables = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+        conn.close()
+        required = {"pipeline_log", "market_data_cache"}
+        missing = required - tables
+        if missing:
+            return CheckResult(
+                "database",
+                "degraded",
+                f"DB reachable but missing tables: {', '.join(sorted(missing))}",
+            )
+        return CheckResult("database", "ok", f"Reachable at {DB_PATH}")
+    except Exception as e:
+        return CheckResult("database", "unavailable", str(e))
+
+
+def _check_universe() -> CheckResult:
+    try:
+        if not UNIVERSE_PATH.exists():
+            return CheckResult("universe", "unavailable", f"Not found: {UNIVERSE_PATH}")
+        lines = [ln for ln in UNIVERSE_PATH.read_text().splitlines() if ln.strip()]
+        ticker_count = max(0, len(lines) - 1)  # subtract header
+        if ticker_count == 0:
+            return CheckResult("universe", "degraded", "universe.csv exists but has no tickers")
+        return CheckResult("universe", "ok", f"{ticker_count} tickers loaded")
+    except Exception as e:
+        return CheckResult("universe", "unavailable", str(e))
+
+
+def _check_exports_writable() -> CheckResult:
+    exports_dir = OUTPUT_DIR / "exports"
+    try:
+        exports_dir.mkdir(parents=True, exist_ok=True)
+        probe = exports_dir / ".write_probe"
+        probe.write_text("ok")
+        probe.unlink()
+        count = len(list(exports_dir.glob("*.xlsx")))
+        return CheckResult("exports_dir", "ok", f"Writable; {count} workbook(s) present")
+    except Exception as e:
+        return CheckResult("exports_dir", "unavailable", str(e))
+
+
+def _check_dossiers() -> CheckResult:
+    try:
+        dossier_path = Path(DOSSIER_ROOT) if not isinstance(DOSSIER_ROOT, Path) else DOSSIER_ROOT
+        if not dossier_path.exists():
+            return CheckResult("dossiers", "degraded", f"Dossier root not found: {dossier_path}")
+        folders = [p for p in dossier_path.iterdir() if p.is_dir()]
+        return CheckResult("dossiers", "ok", f"{len(folders)} dossier(s) available")
+    except Exception as e:
+        return CheckResult("dossiers", "unavailable", str(e))
+
+
+def _check_latest_snapshot() -> CheckResult:
+    valuations_dir = OUTPUT_DIR / "valuations"
+    try:
+        if not valuations_dir.exists():
+            return CheckResult("latest_snapshot", "degraded", "Valuations dir not found — run batch_runner")
+        latest = valuations_dir / "latest.csv"
+        if not latest.exists():
+            return CheckResult("latest_snapshot", "degraded", "latest.csv missing — run batch_runner")
+        size_kb = latest.stat().st_size // 1024
+        return CheckResult("latest_snapshot", "ok", f"latest.csv present ({size_kb} KB)")
+    except Exception as e:
+        return CheckResult("latest_snapshot", "unavailable", str(e))
+
+
+def _check_reports_dir() -> CheckResult:
+    try:
+        REPORTS_DIR.mkdir(parents=True, exist_ok=True)
+        probe = REPORTS_DIR / ".write_probe"
+        probe.write_text("ok")
+        probe.unlink()
+        reports = sorted(REPORTS_DIR.glob("daily_*.md"), reverse=True)
+        if reports:
+            latest = reports[0].name
+            return CheckResult("reports_dir", "ok", f"Writable; latest report: {latest}")
+        return CheckResult("reports_dir", "ok", "Writable; no daily reports yet")
+    except Exception as e:
+        return CheckResult("reports_dir", "unavailable", str(e))
+
+
+def run_diagnostics() -> DiagnosticsPayload:
+    """Run all health checks and return a DiagnosticsPayload."""
+    checks = [
+        _check_database(),
+        _check_universe(),
+        _check_exports_writable(),
+        _check_dossiers(),
+        _check_latest_snapshot(),
+        _check_reports_dir(),
+    ]
+
+    if any(c.status == "unavailable" for c in checks):
+        overall: Status = "unavailable"
+    elif any(c.status == "degraded" for c in checks):
+        overall = "degraded"
+    else:
+        overall = "ok"
+
+    return DiagnosticsPayload(overall=overall, checks=checks)

--- a/src/stage_04_pipeline/diagnostics.py
+++ b/src/stage_04_pipeline/diagnostics.py
@@ -7,12 +7,12 @@ no CIQ refresh.
 """
 from __future__ import annotations
 
-import sqlite3
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
 
 from config import DB_PATH, DOSSIER_ROOT, OUTPUT_DIR, REPORTS_DIR, UNIVERSE_PATH
+from db.schema import get_connection
 
 Status = Literal["ok", "degraded", "unavailable"]
 
@@ -41,14 +41,13 @@ class DiagnosticsPayload:
 
 def _check_database() -> CheckResult:
     try:
-        conn = sqlite3.connect(str(DB_PATH), timeout=2)
-        tables = {
-            row[0]
-            for row in conn.execute(
-                "SELECT name FROM sqlite_master WHERE type='table'"
-            ).fetchall()
-        }
-        conn.close()
+        with get_connection() as conn:
+            tables = {
+                row[0]
+                for row in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                ).fetchall()
+            }
         required = {"pipeline_log", "market_data_cache"}
         missing = required - tables
         if missing:

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,167 @@
+"""Offline tests for operator diagnostics — healthy and degraded states."""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from src.stage_04_pipeline.diagnostics import (
+    DiagnosticsPayload,
+    _check_database,
+    _check_exports_writable,
+    _check_universe,
+    run_diagnostics,
+)
+
+
+# ---------------------------------------------------------------------------
+# as_dict contract (no I/O)
+# ---------------------------------------------------------------------------
+
+def test_as_dict_shape():
+    payload = DiagnosticsPayload(overall="ok", checks=[])
+    d = payload.as_dict()
+    assert d["overall"] == "ok"
+    assert d["checks"] == []
+
+
+def test_as_dict_includes_checks():
+    from src.stage_04_pipeline.diagnostics import CheckResult
+    payload = DiagnosticsPayload(
+        overall="degraded",
+        checks=[CheckResult("database", "degraded", "missing tables: pipeline_log")],
+    )
+    d = payload.as_dict()
+    assert d["overall"] == "degraded"
+    assert len(d["checks"]) == 1
+    assert d["checks"][0] == {
+        "name": "database",
+        "status": "degraded",
+        "message": "missing tables: pipeline_log",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Database check
+# ---------------------------------------------------------------------------
+
+def test_database_ok_when_tables_present(monkeypatch):
+    fake_conn = MagicMock()
+    fake_conn.execute.return_value.fetchall.return_value = [
+        ("pipeline_log",), ("market_data_cache",), ("universe",)
+    ]
+    fake_db = MagicMock(spec=Path)
+    monkeypatch.setattr("src.stage_04_pipeline.diagnostics.DB_PATH", fake_db)
+    with patch("sqlite3.connect", return_value=fake_conn):
+        result = _check_database()
+    assert result.status == "ok"
+
+
+def test_database_degraded_when_tables_missing(monkeypatch):
+    fake_conn = MagicMock()
+    fake_conn.execute.return_value.fetchall.return_value = []  # no tables
+    fake_db = MagicMock(spec=Path)
+    monkeypatch.setattr("src.stage_04_pipeline.diagnostics.DB_PATH", fake_db)
+    with patch("sqlite3.connect", return_value=fake_conn):
+        result = _check_database()
+    assert result.status == "degraded"
+    assert "missing tables" in result.message
+
+
+# ---------------------------------------------------------------------------
+# Universe check
+# ---------------------------------------------------------------------------
+
+def test_universe_ok(monkeypatch):
+    fake_path = MagicMock(spec=Path)
+    fake_path.exists.return_value = True
+    fake_path.read_text.return_value = "ticker,name\nAAPL,Apple\nMSFT,Microsoft\n"
+    monkeypatch.setattr("src.stage_04_pipeline.diagnostics.UNIVERSE_PATH", fake_path)
+    result = _check_universe()
+    assert result.status == "ok"
+    assert "2" in result.message
+
+
+def test_universe_unavailable_when_missing(monkeypatch):
+    fake_path = MagicMock(spec=Path)
+    fake_path.exists.return_value = False
+    monkeypatch.setattr("src.stage_04_pipeline.diagnostics.UNIVERSE_PATH", fake_path)
+    result = _check_universe()
+    assert result.status == "unavailable"
+
+
+def test_universe_degraded_when_empty(monkeypatch):
+    fake_path = MagicMock(spec=Path)
+    fake_path.exists.return_value = True
+    fake_path.read_text.return_value = "ticker,name\n"  # header only
+    monkeypatch.setattr("src.stage_04_pipeline.diagnostics.UNIVERSE_PATH", fake_path)
+    result = _check_universe()
+    assert result.status == "degraded"
+
+
+# ---------------------------------------------------------------------------
+# Exports writable check
+# ---------------------------------------------------------------------------
+
+def test_exports_ok(monkeypatch):
+    fake_dir = MagicMock(spec=Path)
+    fake_dir.__truediv__ = lambda self, other: MagicMock(
+        spec=Path,
+        write_text=MagicMock(),
+        unlink=MagicMock(),
+        **{"glob.return_value": []},
+    )
+    monkeypatch.setattr("src.stage_04_pipeline.diagnostics.OUTPUT_DIR", fake_dir)
+    result = _check_exports_writable()
+    assert result.status == "ok"
+
+
+def test_exports_unavailable_when_write_fails(monkeypatch):
+    probe = MagicMock(spec=Path)
+    probe.write_text.side_effect = PermissionError("read-only")
+    exports_dir = MagicMock(spec=Path)
+    exports_dir.__truediv__ = lambda self, other: probe if other == ".write_probe" else MagicMock()
+    fake_output = MagicMock(spec=Path)
+    fake_output.__truediv__ = lambda self, other: exports_dir
+    monkeypatch.setattr("src.stage_04_pipeline.diagnostics.OUTPUT_DIR", fake_output)
+    result = _check_exports_writable()
+    assert result.status == "unavailable"
+
+
+# ---------------------------------------------------------------------------
+# Overall rollup
+# ---------------------------------------------------------------------------
+
+def test_overall_ok_when_all_checks_pass():
+    from src.stage_04_pipeline.diagnostics import CheckResult
+    with patch("src.stage_04_pipeline.diagnostics._check_database", return_value=CheckResult("database", "ok", "")), \
+         patch("src.stage_04_pipeline.diagnostics._check_universe", return_value=CheckResult("universe", "ok", "")), \
+         patch("src.stage_04_pipeline.diagnostics._check_exports_writable", return_value=CheckResult("exports_dir", "ok", "")), \
+         patch("src.stage_04_pipeline.diagnostics._check_dossiers", return_value=CheckResult("dossiers", "ok", "")), \
+         patch("src.stage_04_pipeline.diagnostics._check_latest_snapshot", return_value=CheckResult("latest_snapshot", "ok", "")), \
+         patch("src.stage_04_pipeline.diagnostics._check_reports_dir", return_value=CheckResult("reports_dir", "ok", "")):
+        payload = run_diagnostics()
+    assert payload.overall == "ok"
+
+
+def test_overall_degraded_when_one_check_degraded():
+    from src.stage_04_pipeline.diagnostics import CheckResult
+    with patch("src.stage_04_pipeline.diagnostics._check_database", return_value=CheckResult("database", "degraded", "missing tables")), \
+         patch("src.stage_04_pipeline.diagnostics._check_universe", return_value=CheckResult("universe", "ok", "")), \
+         patch("src.stage_04_pipeline.diagnostics._check_exports_writable", return_value=CheckResult("exports_dir", "ok", "")), \
+         patch("src.stage_04_pipeline.diagnostics._check_dossiers", return_value=CheckResult("dossiers", "ok", "")), \
+         patch("src.stage_04_pipeline.diagnostics._check_latest_snapshot", return_value=CheckResult("latest_snapshot", "ok", "")), \
+         patch("src.stage_04_pipeline.diagnostics._check_reports_dir", return_value=CheckResult("reports_dir", "ok", "")):
+        payload = run_diagnostics()
+    assert payload.overall == "degraded"
+
+
+def test_overall_unavailable_when_one_check_unavailable():
+    from src.stage_04_pipeline.diagnostics import CheckResult
+    with patch("src.stage_04_pipeline.diagnostics._check_database", return_value=CheckResult("database", "unavailable", "connection refused")), \
+         patch("src.stage_04_pipeline.diagnostics._check_universe", return_value=CheckResult("universe", "ok", "")), \
+         patch("src.stage_04_pipeline.diagnostics._check_exports_writable", return_value=CheckResult("exports_dir", "ok", "")), \
+         patch("src.stage_04_pipeline.diagnostics._check_dossiers", return_value=CheckResult("dossiers", "ok", "")), \
+         patch("src.stage_04_pipeline.diagnostics._check_latest_snapshot", return_value=CheckResult("latest_snapshot", "ok", "")), \
+         patch("src.stage_04_pipeline.diagnostics._check_reports_dir", return_value=CheckResult("reports_dir", "ok", "")):
+        payload = run_diagnostics()
+    assert payload.overall == "unavailable"

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -44,24 +44,24 @@ def test_as_dict_includes_checks():
 # Database check
 # ---------------------------------------------------------------------------
 
-def test_database_ok_when_tables_present(monkeypatch):
+def test_database_ok_when_tables_present():
     fake_conn = MagicMock()
+    fake_conn.__enter__ = lambda s: fake_conn
+    fake_conn.__exit__ = MagicMock(return_value=False)
     fake_conn.execute.return_value.fetchall.return_value = [
         ("pipeline_log",), ("market_data_cache",), ("universe",)
     ]
-    fake_db = MagicMock(spec=Path)
-    monkeypatch.setattr("src.stage_04_pipeline.diagnostics.DB_PATH", fake_db)
-    with patch("sqlite3.connect", return_value=fake_conn):
+    with patch("src.stage_04_pipeline.diagnostics.get_connection", return_value=fake_conn):
         result = _check_database()
     assert result.status == "ok"
 
 
-def test_database_degraded_when_tables_missing(monkeypatch):
+def test_database_degraded_when_tables_missing():
     fake_conn = MagicMock()
-    fake_conn.execute.return_value.fetchall.return_value = []  # no tables
-    fake_db = MagicMock(spec=Path)
-    monkeypatch.setattr("src.stage_04_pipeline.diagnostics.DB_PATH", fake_db)
-    with patch("sqlite3.connect", return_value=fake_conn):
+    fake_conn.__enter__ = lambda s: fake_conn
+    fake_conn.__exit__ = MagicMock(return_value=False)
+    fake_conn.execute.return_value.fetchall.return_value = []
+    with patch("src.stage_04_pipeline.diagnostics.get_connection", return_value=fake_conn):
         result = _check_database()
     assert result.status == "degraded"
     assert "missing tables" in result.message


### PR DESCRIPTION
## Summary

- **`GET /api/health`** — new endpoint returning a `DiagnosticsPayload` with `overall` status and per-check detail for six runtime dependencies
- **`src/stage_04_pipeline/diagnostics.py`** — six offline, deterministic checks: DB reachable + required tables present, universe loaded, exports dir writable, dossiers present, latest.csv exists, reports dir writable
- Each check returns `ok`, `degraded`, or `unavailable` with a plain-English message
- No LLM calls, no live market data, no CIQ
- **12 tests** — healthy state, two degraded states (DB missing tables, universe empty), two unavailable states (DB unreachable, universe file missing, write permission denied), and `as_dict` contract; pure-mock, no `tmp_path` dependency
- **`pyproject.toml`** — `addopts --basetemp=.tmp-tests` + `tmp_path_retention_policy=failed` to keep test scratch local and avoid Windows system-temp permission errors for future `tmp_path` users

## Closes

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)