### PR TITLE
feat: grill fixes MVP — peer universe contract, diagnostic rollup extension, terminal growth cap

### DIFF
--- a/.agent/issue-53-prd.md
+++ b/.agent/issue-53-prd.md
@@ -1,0 +1,119 @@
+## Problem Statement
+
+Alpha Pod produces deterministic valuation outputs, but the PM does not yet have a first-class Assumption Register that shows which valuation assumptions were used, where they came from, whether they sit inside accepted ranges, which ones need review, and which PM approvals may have gone stale.
+
+Today, review context is spread across source lineage, override history, WACC workbench state, DCF diagnostics, and export payloads. This makes it too easy for fragile assumptions to appear beside clean valuations without a clear model trust signal.
+
+## Solution
+
+Build a deterministic V1 Assumption Register for each ticker valuation.
+
+The register should capture Effective Ticker Assumptions, including core DCF drivers, WACC Assumption Inputs, and Terminal Value Drivers. It should expose flag severity, approval state, source lineage, accepted ranges, model trust state, and a compact attention-focused summary for dossier/export/ranking surfaces.
+
+The full register belongs in valuation JSON. Compact summaries should show only trust state, flag counts, max flag, and flagged entries. PM-approved changes continue to flow through the existing override path, with Approval References pointing only to durable PM-applied audit records.
+
+## User Stories
+
+1. As a PM, I want to see every effective ticker assumption used in a valuation, so that I can review the model without hunting through multiple artifacts.
+2. As a PM, I want WACC components to be first-class assumptions, so that I can review the economic story behind the discount rate.
+3. As a PM, I want terminal value drivers to be first-class assumptions, so that I can scrutinize the inputs that often dominate valuation.
+4. As a PM, I want terminal value outputs to remain diagnostics, so that the register does not confuse assumptions with computed results.
+5. As a PM, I want out-of-range assumptions to flag review without blocking computation, so that valuation runs remain reproducible.
+6. As a PM, I want a model trust state, so that fragile valuations are visibly downgraded in ranking and export surfaces.
+7. As a PM, I want trust state to account for selected diagnostics, so that terminal concentration can affect review priority without becoming an assumption.
+8. As a PM, I want PM approvals to become stale when material components change, so that old approvals do not silently remain trusted.
+9. As a PM, I want WACC approvals checked at the component level, so that beta, ERP, size premium, cost of debt, weights, or methodology changes trigger review.
+10. As a PM, I want Approval References to point only to durable PM-applied audit records, so that official approval state is not confused with advisory notes.
+11. As a PM, I want advisory references reserved but not populated in V1, so that future agent context can attach without changing official values.
+12. As a PM, I want source quality to be recognized as important but deferred, so that V1 stays focused while V2 can distinguish strong sources from fallbacks.
+13. As a PM, I want first-seen audit events only for review-relevant entries, so that audit history is meaningful rather than noisy.
+14. As a PM, I want audit rows to store concise diffs, so that material changes are easy to scan.
+15. As a PM, I want override audit and assumption-register audit to remain separate audit families, so that different event types are not mixed.
+16. As a PM, I want valuation impact recorded for override preview/apply paths, so that I can see the effect of approved changes.
+17. As a PM, I do not want automatic per-flag sensitivity runs in V1, so that register generation remains cheap and deterministic.
+18. As a PM, I want accepted ranges to be review ranges rather than hard model clamps, so that bounded values can still be flagged as questionable.
+19. As a PM, I want stable field names, stages, scopes, and affected forecast lines, so that the register is filterable and testable.
+20. As a PM, I want compact dossier/export summaries to show only attention items, so that review surfaces remain focused.
+21. As a developer, I want the public contract to be typed, so that downstream consumers can rely on a stable payload shape.
+22. As a developer, I want internal builders to remain lightweight, so that batch valuation performance is not harmed by unnecessary object construction.
+23. As a developer, I want materiality thresholds centralized, so that provisional rules are inspectable and easy to revise.
+24. As a developer, I want flag semantics defined, so that UI, API, and tests do not invent conflicting meanings.
+25. As a developer, I want owner semantics defined separately from lineage, so that official authority is not confused with provenance.
+26. As a developer, I want scenario assumption packs deferred to V2, so that V1 does not flatten multi-assumption cases into misleading single rows.
+27. As a developer, I want sector/global policy rows deferred to V2, so that V1 stays focused on effective ticker assumptions.
+28. As a downstream consumer, I want the full register in valuation JSON, so that detailed drill-down is available.
+29. As a downstream consumer, I want the ticker dossier to carry only a compact summary, so that payloads stay lightweight.
+30. As a reviewer, I want tests around contract round-trips, builder output, flagging, trust state, audit diffs, and export/API payloads, so that regressions are caught at the behavior boundary.
+
+## Implementation Decisions
+
+- Build one coherent V1 PR with internally sliced commits/checkpoints.
+- Define a shared Assumption Register contract at the public boundary.
+- Let valuation-specific builder logic construct lightweight internal payloads, then validate once against the shared contract.
+- Populate V1 entries as Effective Ticker Assumptions.
+- Preserve sector/global origins in lineage and scope, but do not create sector/global policy entries in V1.
+- Include core DCF drivers already shown in the assumptions workbench.
+- Include WACC Assumption Inputs: final WACC, risk-free rate, equity risk premium, beta, size premium, cost of debt, equity/debt weights, and selected methodology when available.
+- Include Terminal Value Drivers: terminal growth, terminal RONIC, exit multiple, and terminal blend weights.
+- Exclude scenario probabilities and context scenario outputs from V1.
+- Reserve advisory attachment fields, but leave them empty in V1.
+- Keep Source Quality State in V2.
+- Keep automatic sensitivity-driven Valuation Impact scoring in V2.
+- Use `owner` only for official authority: deterministic, PM override, or system flag.
+- Keep detailed provenance in source lineage, Approval References, and Advisory References.
+- Make Approval References point only to durable PM-applied audit rows.
+- Define deterministic Flag Level semantics for none, watch, review required, and critical.
+- Define Model Trust State as a deterministic rollup of assumption flags plus selected valuation diagnostics.
+- Define stable naming conventions for assumption names, stages, scopes, and affected forecast lines.
+- Treat accepted ranges as PM-review ranges for effective values, not necessarily the same as numerical hard clamps.
+- Keep raw/pre-clamp value diagnostics out of V1 unless they are easy to mention in notes or evidence references.
+- Add append-only assumption-register audit for review-relevant material events.
+- Store concise audit diffs, not full entry snapshots or full-register snapshots.
+- Keep override audit rows and assumption-register audit rows as separate API families.
+- Put the full Assumption Register in valuation JSON.
+- Add compact Assumption Register Summary to dossier/export/ranking surfaces.
+- Compact summaries include trust state, flag counts, max flag, and flagged entries only.
+- Preserve deterministic valuation output even when flags are critical.
+
+## Testing Decisions
+
+- Test external behavior and contracts, not implementation details.
+- Test JSON round-trip behavior for the shared Assumption Register contract.
+- Test that the builder validates final payloads against the shared contract.
+- Test deterministic builder output for numeric effective ticker assumptions.
+- Test WACC components as first-class entries.
+- Test terminal value drivers as entries and terminal outputs as diagnostics.
+- Test static accepted-range flagging.
+- Test that out-of-range values do not block valuation.
+- Test flag-level semantics for none, watch, review required, and critical.
+- Test model trust rollup from flags and selected diagnostics.
+- Test materiality rules by field class.
+- Test component-level stale approval behavior for WACC inputs.
+- Test that audit rows store concise diffs.
+- Test that first-seen audit logging is review-relevant only.
+- Test valuation result includes the register.
+- Test valuation JSON includes the full register.
+- Test assumptions API payload includes separate override and assumption-register audit families.
+- Test override preview/apply paths can include valuation-impact metadata.
+- Test ticker dossier/export surfaces include compact summaries only.
+- Use existing API contract, JSON exporter, override workbench, batch runner, and ticker dossier tests as prior art.
+
+## Out of Scope
+
+- LLM or judgment-layer population of official register entries.
+- Automatic mutation of deterministic valuation inputs from advisory output.
+- Source Quality State implementation.
+- Scenario Assumption Packs.
+- Sector, industry, or global policy-entry population.
+- Damodaran data ingestion or range-policy integration.
+- Historical, peer, industry, or scale-aware accepted ranges.
+- Automatic per-flag sensitivity or valuation-impact scoring.
+- Raw/pre-clamp value fields in the V1 contract.
+- Broad React redesign.
+- Config editor for range rules or assumptions.
+
+## Further Notes
+
+The key invariant remains unchanged: LLMs and advisory agents may inform PM review, but they must not mutate official valuation inputs except through a PM-approved override path.
+
+V1 should make the deterministic valuation easier to audit without turning the register into a second valuation engine. The register is the PM-facing map of assumptions and review state; the existing valuation math remains the system of record for computed outputs.

--- a/.agent/session-state.md
+++ b/.agent/session-state.md
@@ -1,34 +1,36 @@
 # Session State
 
-**Updated:** 2026-05-11 01:01:32 +02:00
+**Updated:** 2026-05-11 01:26:51 +02:00
 **Agent:** Codex CLI
 **Project:** C:\Projects\03-Finance\ai-fund
 
 ## Current Task
-Finalize Assumption Register Contract planning/PRD on branch `53-assumption-register-contract`.
+Implemented deterministic V1 Assumption Register on branch `53-assumption-register-contract`.
 
 ## Recent Actions
-- Used `grill-with-docs` to resolve high-impact Assumption Register contract choices.
-- Created root `CONTEXT.md` with the valuation glossary and resolved ambiguities.
-- Updated `docs/plans/2026-05-06-assumption-register-contract.md` with the resolved V1/V2 contract decisions.
-- Used `to-prd` to synthesize the current context into a PRD.
-- Updated GitHub issue `#53`: https://github.com/smrik/ai-fund/issues/53
-- Added local PRD body artifact at `.agent/issue-53-prd.md`.
+- Committed the planning baseline first: `CONTEXT.md`, `.agent/issue-53-prd.md`, `.agent/session-state.md`, and `docs/plans/2026-05-06-assumption-register-contract.md`.
+- Added strict Pydantic V2 contract models in `src/contracts/assumption_register.py`.
+- Added Stage 02 builder, static range rules, materiality rules, compact summary, and audit diff logic in `src/stage_02_valuation/assumption_register.py`.
+- Added separate append-only `assumption_register_audit` schema plus insert/list helpers in `db/schema.py` and `db/loader.py`.
+- Wired `value_single_ticker()` to emit `assumption_register_json`, compact summary JSON, trust state, max flag, and flag counts.
+- Wired JSON export, override workbench, valuation assumptions API, and ticker dossier adapters to expose full register or compact summary as planned.
+- Updated the valuation methodology critical-review memo with V1 implementation status and V2 leftovers.
+- Used `requesting-code-review` as a local review pass; no blocking issues found.
 
 ## Next Steps
-- Commit `CONTEXT.md`, `.agent/issue-53-prd.md`, `.agent/session-state.md`, and `docs/plans/2026-05-06-assumption-register-contract.md` if the decision baseline should be preserved before implementation.
-- If implementing, use `executing-plans` first and work against `docs/plans/2026-05-06-assumption-register-contract.md`.
-- Use `requesting-code-review` before final review or PR handoff.
+- Review the diff and commit implementation changes when ready.
+- Optional: broaden tests beyond the focused bundle if you want extra regression confidence before PR.
+- Optional: decide whether automatic persistence of assumption-register audit diffs should be called by a specific scheduled workflow, or stay helper/API-ready in V1.
 
 ## Known Issues
-- Working tree has modified `.agent/session-state.md` and `docs/plans/2026-05-06-assumption-register-contract.md`.
-- Untracked `CONTEXT.md` and `.agent/issue-53-prd.md` are intentional planning artifacts.
-- Untracked `course/` exists and should be left alone unless the user explicitly says otherwise.
-- A safety stash still exists: `stash@{0}: On 45-periodic-audit-routine: assumption-register-plan-refine`; it has been applied to the feature branch but not dropped.
-- Git index-writing commands may need escalation on this Windows checkout.
-- `bash` routes to WSL, but WSL has no installed distro; use Git for Windows tools directly when needed.
+- Untracked `course/` still exists and was intentionally left untouched.
+- `.pytest_cache` is permission-restricted on this Windows checkout, so pytest emits cache warnings. Tests still pass.
+- A stale ignored `.tmp-tests/diag` folder initially blocked the repo default pytest basetemp; it was removed and the exact focused pytest command now passes.
+- A safety stash from the planning session may still exist: `stash@{0}: On 45-periodic-audit-routine: assumption-register-plan-refine`.
 
 ## Notes
-- Core V1 direction: deterministic-only, numeric effective ticker assumptions, WACC components and terminal drivers first-class, model trust state, compact summaries, review-relevant audit diffs, separate audit families.
-- V2 backlog: source quality state, advisory population through `driver_assessments.py`, scenario assumption packs, sector/global policy entries, Damodaran/history/industry ranges, automatic sensitivity-driven impact scoring, raw/pre-clamp diagnostics.
-- Use `rtk` for Git, test, and repo-inspection commands where available.
+- Verification passed:
+  - `rtk python -m pytest tests/test_assumption_register.py tests/test_api_contracts.py tests/test_batch_runner_professional.py tests/test_json_exporter.py tests/test_override_workbench.py tests/test_ticker_dossier_contract_runtime.py -q`
+  - `rtk python -m mkdocs build --strict`
+  - `rtk git diff --check`
+- Focused pytest result: 75 passed, with third-party deprecation warnings and the existing `.pytest_cache` permission warning.

--- a/.agent/session-state.md
+++ b/.agent/session-state.md
@@ -1,25 +1,34 @@
 # Session State
 
-**Updated:** 2026-05-06 18:03:54 +02:00
+**Updated:** 2026-05-11 01:01:32 +02:00
 **Agent:** Codex CLI
 **Project:** C:\Projects\03-Finance\ai-fund
 
 ## Current Task
-Propagate the `industry_agent.py` initialization-style refactor pattern across all `src/stage_03_judgment/*agent.py` modules.
+Finalize Assumption Register Contract planning/PRD on branch `53-assumption-register-contract`.
 
 ## Recent Actions
-- Inspected `industry_agent.py` refactor commit (`e7ef78f`) and compared all stage_03 agent modules.
-- Standardized agent constructors to use explicit per-agent model env overrides with deterministic defaults and `super().__init__(model=...)` across judgment agents.
-- Added `from __future__ import annotations` where missing in agent modules.
-- Ran `python -m compileall src/stage_03_judgment` successfully to verify syntax/import integrity.
+- Used `grill-with-docs` to resolve high-impact Assumption Register contract choices.
+- Created root `CONTEXT.md` with the valuation glossary and resolved ambiguities.
+- Updated `docs/plans/2026-05-06-assumption-register-contract.md` with the resolved V1/V2 contract decisions.
+- Used `to-prd` to synthesize the current context into a PRD.
+- Updated GitHub issue `#53`: https://github.com/smrik/ai-fund/issues/53
+- Added local PRD body artifact at `.agent/issue-53-prd.md`.
 
 ## Next Steps
-- Run targeted runtime tests for stage_03 pipeline paths to validate behavior under existing orchestration flows.
-- Review default model constants if PM wants different model routing per agent.
+- Commit `CONTEXT.md`, `.agent/issue-53-prd.md`, `.agent/session-state.md`, and `docs/plans/2026-05-06-assumption-register-contract.md` if the decision baseline should be preserved before implementation.
+- If implementing, use `executing-plans` first and work against `docs/plans/2026-05-06-assumption-register-contract.md`.
+- Use `requesting-code-review` before final review or PR handoff.
 
 ## Known Issues
-- Behavior-level parity not yet validated with end-to-end stage_03 orchestration tests in this session.
+- Working tree has modified `.agent/session-state.md` and `docs/plans/2026-05-06-assumption-register-contract.md`.
+- Untracked `CONTEXT.md` and `.agent/issue-53-prd.md` are intentional planning artifacts.
+- Untracked `course/` exists and should be left alone unless the user explicitly says otherwise.
+- A safety stash still exists: `stash@{0}: On 45-periodic-audit-routine: assumption-register-plan-refine`; it has been applied to the feature branch but not dropped.
+- Git index-writing commands may need escalation on this Windows checkout.
+- `bash` routes to WSL, but WSL has no installed distro; use Git for Windows tools directly when needed.
 
 ## Notes
-- Files touched: accounting_recast_agent.py, earnings_agent.py, filings_agent.py, macro_agent.py, qoe_agent.py, research_note_agent.py, risk_agent.py, risk_impact_agent.py, sentiment_agent.py, thesis_agent.py, valuation_agent.py.
-- No changes made to deterministic stage_02 valuation logic.
+- Core V1 direction: deterministic-only, numeric effective ticker assumptions, WACC components and terminal drivers first-class, model trust state, compact summaries, review-relevant audit diffs, separate audit families.
+- V2 backlog: source quality state, advisory population through `driver_assessments.py`, scenario assumption packs, sector/global policy entries, Damodaran/history/industry ranges, automatic sensitivity-driven impact scoring, raw/pre-clamp diagnostics.
+- Use `rtk` for Git, test, and repo-inspection commands where available.

--- a/.agent/session-state.md
+++ b/.agent/session-state.md
@@ -1,36 +1,37 @@
 # Session State
 
-**Updated:** 2026-05-11 01:26:51 +02:00
+**Updated:** 2026-05-11 15:05:52 +02:00
 **Agent:** Codex CLI
 **Project:** C:\Projects\03-Finance\ai-fund
 
 ## Current Task
-Implemented deterministic V1 Assumption Register on branch `53-assumption-register-contract`.
+Implemented the next Assumption Register extension slice: editable valuation policy defaults, Damodaran drop-folder draft parsing, DB-canonical pending/approved assumption changes, stacked preview/apply APIs, React Pending Changes surface, and approved-register override wiring into input assembly.
 
 ## Recent Actions
-- Committed the planning baseline first: `CONTEXT.md`, `.agent/issue-53-prd.md`, `.agent/session-state.md`, and `docs/plans/2026-05-06-assumption-register-contract.md`.
-- Added strict Pydantic V2 contract models in `src/contracts/assumption_register.py`.
-- Added Stage 02 builder, static range rules, materiality rules, compact summary, and audit diff logic in `src/stage_02_valuation/assumption_register.py`.
-- Added separate append-only `assumption_register_audit` schema plus insert/list helpers in `db/schema.py` and `db/loader.py`.
-- Wired `value_single_ticker()` to emit `assumption_register_json`, compact summary JSON, trust state, max flag, and flag counts.
-- Wired JSON export, override workbench, valuation assumptions API, and ticker dossier adapters to expose full register or compact summary as planned.
-- Updated the valuation methodology critical-review memo with V1 implementation status and V2 leftovers.
-- Used `requesting-code-review` as a local review pass; no blocking issues found.
+- Added `src/contracts/assumption_policy.py` with Pydantic V2 policy, Damodaran draft, pending-change, and stack-preview contracts.
+- Added DB tables/helpers for valuation policy versions, Damodaran policy drafts, pending assumption changes, and approved assumption entries.
+- Added `src/stage_04_pipeline/assumption_policy.py` and `src/stage_04_pipeline/pending_assumption_changes.py` services.
+- Wired FastAPI endpoints for valuation policy get/preview/save, Damodaran parse, pending-change list/preview/apply.
+- Wired `input_assembler.py` so approved DB register entries override legacy YAML values, and WACC now receives editable policy Rf/ERP at runtime.
+- Updated recommendation writes to queue numeric recommendations as pending register changes when using the canonical config path; legacy YAML remains a compatibility copy.
+- Added React Assumptions UI sections for policy defaults and pending changes.
+- Added focused tests in `tests/test_assumption_policy.py`, plus API and input-assembler coverage.
 
 ## Next Steps
-- Review the diff and commit implementation changes when ready.
-- Optional: broaden tests beyond the focused bundle if you want extra regression confidence before PR.
-- Optional: decide whether automatic persistence of assumption-register audit diffs should be called by a specific scheduled workflow, or stay helper/API-ready in V1.
+- Review the diff and commit if satisfied.
+- Optional: broaden React interaction tests for the new policy editor and pending-changes table.
+- Optional: decide whether to remove the legacy YAML mirror in a later PR once all consumers are migrated.
 
 ## Known Issues
 - Untracked `course/` still exists and was intentionally left untouched.
-- `.pytest_cache` is permission-restricted on this Windows checkout, so pytest emits cache warnings. Tests still pass.
-- A stale ignored `.tmp-tests/diag` folder initially blocked the repo default pytest basetemp; it was removed and the exact focused pytest command now passes.
-- A safety stash from the planning session may still exist: `stash@{0}: On 45-periodic-audit-routine: assumption-register-plan-refine`.
+- `.pytest_cache` remains permission-restricted on this Windows checkout; pytest emits cache warnings but tests pass.
+- `tests/test_wacc.py` still has pre-existing size-premium expectation failures against the current WACC implementation when run outside the focused bundle.
 
 ## Notes
 - Verification passed:
-  - `rtk python -m pytest tests/test_assumption_register.py tests/test_api_contracts.py tests/test_batch_runner_professional.py tests/test_json_exporter.py tests/test_override_workbench.py tests/test_ticker_dossier_contract_runtime.py -q`
+  - `rtk python -m pytest tests/test_assumption_policy.py tests/test_assumption_register.py tests/test_api_contracts.py tests/test_batch_runner_professional.py tests/test_json_exporter.py tests/test_override_workbench.py tests/test_recommendations.py tests/test_ticker_dossier_contract_runtime.py tests/test_valuation_input_assembler.py -q`
+  - `npm --prefix frontend run build`
   - `rtk python -m mkdocs build --strict`
   - `rtk git diff --check`
-- Focused pytest result: 75 passed, with third-party deprecation warnings and the existing `.pytest_cache` permission warning.
+- Focused pytest result: 123 passed, with existing json_exporter deprecation warnings and the `.pytest_cache` permission warning.
+- A broad extra probe of `tests/test_wacc.py` failed on pre-existing size-premium expectations; no changes were made there in this pass.

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ data/cache/
 data/dossiers/
 data/valuations/
 data/exports/
+data/damodaran_drop/
 data/alpha_pod.db
 data/tracker-test-*.db
 data/stage1_survivors.csv

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,154 @@
+# Alpha Pod Valuation Context
+
+This context captures the domain language for Alpha Pod's valuation workflow. It exists so agents, docs, and implementation plans use the same words for assumptions, approvals, and PM review.
+
+## Language
+
+**Assumption Register**:
+The official map of valuation assumptions, accepted ranges, source lineage, flags, and approval state.
+_Avoid_: Override register, assumption table
+
+**Override Register**:
+The narrower record of PM-approved changes that may mutate deterministic valuation assumptions.
+_Avoid_: Assumption register, approval queue
+
+**PM Decision Queue**:
+The review workflow surface where flagged assumptions, advisory suggestions, and material valuation changes are triaged by the PM.
+_Avoid_: Override register, assumption register
+
+**WACC Assumption Inputs**:
+The PM-reviewable cost-of-capital assumptions and components that explain the final WACC used in a valuation.
+_Avoid_: WACC audit internals, single WACC assumption
+
+**Stale Approval**:
+A previously approved assumption state that requires PM review because the approved value or one of its material components changed.
+_Avoid_: Still approved, expired approval
+
+**Model Trust State**:
+The valuation-level review state that tells the PM whether computed outputs are clean, review-required, or critical-review-required.
+_Avoid_: Block status, pass/fail
+
+**Advisory Reference**:
+A reserved pointer from an official assumption to non-authoritative judgment-layer context that may inform PM review later.
+_Avoid_: Official action, approval status, LLM input
+
+**Source Quality State**:
+The PM-facing confidence class for where an assumption came from, separate from whether the numeric value is inside its accepted range.
+_Avoid_: Range flag, source lineage
+
+**Review-Relevant Audit Event**:
+An assumption-register event worth preserving because it affects PM attention, approval state, flags, source, range rule, or material value movement.
+_Avoid_: Snapshot row, every generated assumption
+
+**Valuation Impact**:
+The measured change in intrinsic value or expected value from a proposed assumption change.
+_Avoid_: Flag severity, source quality
+
+**Effective Ticker Assumption**:
+The final assumption value used for one ticker valuation after deterministic defaults, lineage, and approved overrides are resolved.
+_Avoid_: Sector policy entry, global policy entry
+
+**Scenario Assumption Pack**:
+A coherent multi-assumption valuation case, such as bear, base, bull, or context-aware scenarios.
+_Avoid_: Single assumption, ordinary DCF driver
+
+**Terminal Value Driver**:
+A PM-reviewable assumption that defines the mature-state economics or terminal valuation method for a DCF.
+_Avoid_: Terminal diagnostic, terminal output
+
+**Approval Reference**:
+A pointer from an official assumption state to the durable PM-applied audit record that authorized it.
+_Avoid_: Advisory reference, pending recommendation
+
+**Flag Level**:
+The deterministic severity label that tells the PM how urgently an assumption or valuation state needs review.
+_Avoid_: Error status, approval state
+
+**Assumption Owner**:
+The authority responsible for the official assumption value: deterministic system logic, PM override, or system-generated flag.
+_Avoid_: Source lineage, data source
+
+**Assumption Field Name**:
+The machine-stable key for an assumption, preferably matching the valuation driver or WACC input field name.
+_Avoid_: Display label, prose name
+
+**Assumption Register Summary**:
+The compact attention-focused rollup of register state for dossier, export, and ranking surfaces.
+_Avoid_: Full assumption register, clean assumption list
+
+**Contract Boundary**:
+The point where a payload is validated against the shared public model before crossing module or surface boundaries.
+_Avoid_: Internal builder representation, every intermediate object
+
+**Accepted Range**:
+The PM-review range used to assess whether an effective assumption deserves attention, distinct from numerical clamps used to keep the model computable.
+_Avoid_: Hard clamp, validation bound
+
+**Audit Diff**:
+The minimal before/after change payload recorded for a review-relevant assumption event.
+_Avoid_: Full entry snapshot, full register snapshot
+
+**Materiality Rule**:
+A centralized threshold rule that determines whether an assumption change is meaningful enough to affect audit, approval, or review state.
+_Avoid_: Inline threshold, scattered if-branch
+
+**Audit Family**:
+A named group of audit events with a shared source and meaning, such as PM override history or assumption-register material diffs.
+_Avoid_: Generic audit rows, mixed audit list
+
+## Relationships
+
+- The **Assumption Register** includes deterministic assumptions and their review state.
+- The **Override Register** records PM-approved mutations that can affect entries in the **Assumption Register**.
+- The **PM Decision Queue** consumes **Assumption Register** flags and advisory suggestions but is not the source of truth for official model inputs.
+- **WACC Assumption Inputs** are included in the **Assumption Register** because cost of capital components are material to PM review.
+- **Stale Approval** is assessed at the component level for **WACC Assumption Inputs**, even when final WACC has not moved materially.
+- **Model Trust State** is derived from **Assumption Register** flags and affects review priority without preventing deterministic computation.
+- **Model Trust State** may also incorporate valuation diagnostics, such as terminal concentration, without turning diagnostics into assumptions.
+- An **Advisory Reference** may point from an **Assumption Register** entry to judgment-layer context, but it does not change official assumption state.
+- **Source Quality State** is a future review dimension for the **Assumption Register**, not a V1 field.
+- A **Review-Relevant Audit Event** is appended only when an assumption needs PM attention or its meaningful review state changed.
+- **Valuation Impact** is recorded in V1 when the PM previews or applies an override, not automatically for every flagged assumption.
+- V1 **Assumption Register** entries are **Effective Ticker Assumptions** even when their lineage points to sector or global policy inputs.
+- **Scenario Assumption Packs** are future objects separate from V1 single-value **Assumption Register** entries.
+- **Terminal Value Drivers** are first-class V1 **Assumption Register** entries; terminal value outputs remain diagnostics.
+- An **Approval Reference** points to PM-applied override audit history, while an **Advisory Reference** points to non-authoritative judgment context.
+- A **Flag Level** is separate from approval state: flags describe review severity, while approval state describes PM authorization.
+- **Assumption Owner** identifies official authority, while source lineage records detailed provenance.
+- **Assumption Field Names**, stages, scopes, and affected forecast lines should use stable vocabulary so register entries remain filterable.
+- The **Assumption Register Summary** includes trust state, flag counts, max flag, and flagged entries; full clean entries remain in the full register.
+- The **Contract Boundary** for the assumption register is the shared Pydantic model; internal builders may use lighter representations before final validation.
+- An **Accepted Range** is a review boundary for the final effective value, not necessarily the same as the hard clamps used during input assembly.
+- A **Review-Relevant Audit Event** stores an **Audit Diff**, while the full current state remains in the **Assumption Register**.
+- **Materiality Rules** are centralized so provisional thresholds can be inspected, tested, and revised.
+- Different **Audit Families** should remain separate in API payloads unless a surface explicitly asks for a merged timeline.
+
+## Example dialogue
+
+> **Dev:** "Should the QoE agent write this EBIT adjustment into the **Assumption Register**?"
+> **Domain expert:** "No. It should appear in the **PM Decision Queue** first. If approved, the **Override Register** records the PM-approved change, and the **Assumption Register** reflects the resulting official assumption state."
+
+## Flagged ambiguities
+
+- "Register" was used for both the full assumption map and the PM override trail. Resolved: **Assumption Register** is the full official assumption map; **Override Register** is only the PM-approved mutation trail.
+- "WACC" was initially treated as possibly one assumption plus audit detail. Resolved: **WACC Assumption Inputs** are first-class review entries because the PM considers each cost-of-capital component material.
+- "Approval" for WACC was ambiguous between final-WACC approval and component approval. Resolved: component-level changes can create **Stale Approval** even when headline WACC movement is small.
+- "Blocking" was considered for out-of-range assumptions. Resolved: V1 computes and exports valuations, while **Model Trust State** downgrades fragile outputs for ranking and review.
+- **Model Trust State** was ambiguous between a pure max-flag rollup and a broader valuation-quality signal. Resolved: it is a deterministic rollup of assumption flags plus selected valuation diagnostics.
+- `driver_assessments.py` workflow states were considered for V1. Resolved: V1 reserves **Advisory Reference** fields only; official approval state remains deterministic and PM-owned.
+- "In range" was considered as possibly enough to trust an assumption. Resolved: **Source Quality State** should eventually distinguish strong sources from fallbacks, but stays V2.
+- `first_seen` audit logging was ambiguous. Resolved: V1 logs first-seen events only when they are **Review-Relevant Audit Events**, not for every generated baseline assumption.
+- `valuation_impact` was ambiguous between static register metadata and preview/apply evidence. Resolved: **Valuation Impact** is required for PM override preview/apply paths in V1; automatic per-flag sensitivity belongs in V2.
+- `entity_type` was ambiguous for values sourced from sector/global policy. Resolved: V1 entries are **Effective Ticker Assumptions** with `entity_type = ticker`; sector/global policy entries are V2.
+- Scenario probabilities and context scenario outputs were considered for V1. Resolved: scenarios become **Scenario Assumption Packs** in V2, not flattened V1 assumption entries.
+- Terminal value could mean assumptions or computed outputs. Resolved: **Terminal Value Drivers** are V1 assumption entries, while terminal concentration and value outputs are diagnostics.
+- `approval_ref` could have pointed to pending recommendations or advisory files. Resolved: **Approval Reference** points only to durable PM-applied records such as override or WACC methodology audit rows.
+- `FlagLevel` was underdefined. Resolved: **Flag Level** values must have deterministic semantics: `none`, `watch`, `review_required`, and `critical`.
+- `owner` was ambiguous between authority and provenance. Resolved: **Assumption Owner** is coarse official authority; detailed origin stays in source lineage and approval/advisory references.
+- Naming fields were at risk of becoming free-form labels. Resolved: V1 uses stable **Assumption Field Names** and controlled stage/scope/forecast-line vocabularies.
+- Compact dossier/export content was ambiguous. Resolved: **Assumption Register Summary** is attention-focused and does not include clean-but-important assumptions in V1.
+- Pydantic usage was ambiguous between public contract and every builder step. Resolved: validate at the **Contract Boundary**, while internal construction may stay lightweight.
+- Accepted ranges were at risk of duplicating hard clamps. Resolved: **Accepted Range** is a PM-review concept; V1 records effective values and may mention raw/pre-clamp evidence in notes or evidence refs when readily available.
+- Audit payload shape was ambiguous between full snapshots and diffs. Resolved: V1 audit rows store **Audit Diff** payloads, not full entry or full-register snapshots.
+- Materiality thresholds were at risk of becoming scattered conditionals. Resolved: V1 uses centralized **Materiality Rules** keyed by field class or scope.
+- API audit rows were ambiguous between override history and assumption-register history. Resolved: V1 exposes separate **Audit Families** rather than one mixed list.

--- a/api/extracted.py
+++ b/api/extracted.py
@@ -557,6 +557,7 @@ def build_ticker_workspace_payload(ticker: str, dossier_payload: dict[str, Any] 
                 "snapshot_id",
                 "last_snapshot_date",
                 "ticker_dossier_contract_version",
+                "assumption_register_summary",
             ],
         )
     return _attach_api_ticker_dossier(payload, ticker, dossier_payload=dossier_payload)
@@ -665,6 +666,7 @@ def build_valuation_summary_payload(ticker: str) -> dict[str, Any]:
                 "memo_date",
                 "why_it_matters",
                 "ticker_dossier_contract_version",
+                "assumption_register_summary",
             ],
         )
     return _attach_api_ticker_dossier(payload, ticker, dossier_payload=dossier_payload)
@@ -689,8 +691,12 @@ def build_valuation_assumptions_payload(ticker: str) -> dict[str, Any]:
         **workbench,
     }
     from src.stage_04_pipeline.override_workbench import load_override_audit_history
+    from src.stage_04_pipeline.override_workbench import load_assumption_register_audit_history
 
-    payload["audit_rows"] = load_override_audit_history(ticker, limit=50)
+    override_audit_rows = load_override_audit_history(ticker, limit=50)
+    payload["override_audit_rows"] = override_audit_rows
+    payload["assumption_register_audit_rows"] = load_assumption_register_audit_history(ticker, limit=50)
+    payload["audit_rows"] = override_audit_rows
     return payload
 
 

--- a/api/main.py
+++ b/api/main.py
@@ -57,6 +57,21 @@ class RecommendationsApplyRequest(BaseModel):
     approved_fields: list[str] = Field(default_factory=list)
 
 
+class ValuationPolicyEditRequest(BaseModel):
+    global_defaults: dict[str, float] = Field(default_factory=dict)
+    sector_defaults: dict[str, dict[str, float]] = Field(default_factory=dict)
+    notes: str | None = None
+
+
+class PendingAssumptionPreviewRequest(BaseModel):
+    change_ids: list[int] = Field(default_factory=list)
+    manual_values: dict[str, float] = Field(default_factory=dict)
+
+
+class PendingAssumptionApplyRequest(BaseModel):
+    change_ids: list[int] = Field(default_factory=list)
+
+
 class AnalysisRunRequest(BaseModel):
     use_cache: bool = True
     force_refresh_agents: list[str] = Field(default_factory=list)
@@ -344,6 +359,65 @@ def apply_recommendations_to_overrides(
     return _impl(ticker, approved_fields=approved_fields, actor=actor)
 
 
+def load_valuation_policy_payload() -> dict[str, Any]:
+    from src.stage_04_pipeline.assumption_policy import load_current_valuation_policy
+
+    return load_current_valuation_policy().model_dump()
+
+
+def preview_valuation_policy_payload(payload: ValuationPolicyEditRequest) -> dict[str, Any]:
+    from src.stage_04_pipeline.assumption_policy import preview_valuation_policy_edits
+
+    return preview_valuation_policy_edits(
+        global_defaults=payload.global_defaults,
+        sector_defaults=payload.sector_defaults,
+    ).model_dump()
+
+
+def save_valuation_policy_payload(payload: ValuationPolicyEditRequest, actor: str = "api") -> dict[str, Any]:
+    from src.stage_04_pipeline.assumption_policy import preview_valuation_policy_edits, save_valuation_policy
+
+    preview = preview_valuation_policy_edits(
+        global_defaults=payload.global_defaults,
+        sector_defaults=payload.sector_defaults,
+    )
+    policy = preview.proposed_policy.model_copy(update={"notes": payload.notes})
+    return save_valuation_policy(policy, actor=actor).model_dump()
+
+
+def parse_damodaran_policy_drafts_payload() -> dict[str, Any]:
+    from src.stage_04_pipeline.assumption_policy import parse_damodaran_drop_folder
+
+    return parse_damodaran_drop_folder()
+
+
+def list_pending_assumptions_payload(ticker: str) -> dict[str, Any]:
+    from src.stage_04_pipeline.pending_assumption_changes import list_pending_assumption_changes
+
+    changes = [change.model_dump() for change in list_pending_assumption_changes(ticker)]
+    return {"ticker": ticker.upper(), "pending_changes": changes}
+
+
+def preview_pending_assumptions_payload(
+    ticker: str,
+    change_ids: list[int],
+    manual_values: dict[str, float] | None = None,
+) -> dict[str, Any]:
+    from src.stage_04_pipeline.pending_assumption_changes import preview_pending_assumption_stack
+
+    return preview_pending_assumption_stack(ticker, change_ids, manual_values=manual_values).model_dump()
+
+
+def apply_pending_assumptions_payload(
+    ticker: str,
+    change_ids: list[int],
+    actor: str = "api",
+) -> dict[str, Any]:
+    from src.stage_04_pipeline.pending_assumption_changes import apply_pending_assumption_stack
+
+    return apply_pending_assumption_stack(ticker, change_ids, actor=actor)
+
+
 build_ticker_overview_payload = build_overview_payload
 
 
@@ -582,6 +656,54 @@ def create_app() -> FastAPI:
             )
 
         run_id = submit_background_run("valuation_recommendations_apply", _runner, ticker=ticker)
+        return {"run_id": run_id, "status": "queued"}
+
+    @app.get("/api/valuation/policy")
+    def get_valuation_policy() -> dict[str, Any]:
+        return load_valuation_policy_payload()
+
+    @app.post("/api/valuation/policy/preview")
+    def preview_valuation_policy(payload: ValuationPolicyEditRequest | None = None) -> dict[str, Any]:
+        return preview_valuation_policy_payload(payload or ValuationPolicyEditRequest())
+
+    @app.put("/api/valuation/policy")
+    def save_valuation_policy(payload: ValuationPolicyEditRequest | None = None) -> dict[str, Any]:
+        return save_valuation_policy_payload(payload or ValuationPolicyEditRequest(), actor="api")
+
+    @app.post("/api/valuation/policy/damodaran/parse")
+    def parse_damodaran_policy_drafts() -> dict[str, Any]:
+        return parse_damodaran_policy_drafts_payload()
+
+    @app.get("/api/tickers/{ticker}/valuation/pending-changes")
+    def get_ticker_pending_assumption_changes(ticker: str) -> dict[str, Any]:
+        ticker = api_coerce_ticker(ticker)
+        return list_pending_assumptions_payload(ticker)
+
+    @app.post("/api/tickers/{ticker}/valuation/pending-changes/preview")
+    def preview_ticker_pending_assumption_changes(
+        ticker: str,
+        payload: PendingAssumptionPreviewRequest | None = None,
+    ) -> dict[str, Any]:
+        ticker = api_coerce_ticker(ticker)
+        request_payload = payload or PendingAssumptionPreviewRequest()
+        return preview_pending_assumptions_payload(
+            ticker,
+            request_payload.change_ids,
+            manual_values=request_payload.manual_values,
+        )
+
+    @app.post("/api/tickers/{ticker}/valuation/pending-changes/apply", status_code=202)
+    def apply_ticker_pending_assumption_changes(
+        ticker: str,
+        payload: PendingAssumptionApplyRequest | None = None,
+    ) -> dict[str, Any]:
+        ticker = api_coerce_ticker(ticker)
+        request_payload = payload or PendingAssumptionApplyRequest()
+
+        def _runner(_run_id: str) -> dict[str, Any]:
+            return apply_pending_assumptions_payload(ticker, request_payload.change_ids, actor="api")
+
+        run_id = submit_background_run("valuation_pending_changes_apply", _runner, ticker=ticker)
         return {"run_id": run_id, "status": "queued"}
 
     @app.get("/api/tickers/{ticker}/market")

--- a/db/loader.py
+++ b/db/loader.py
@@ -673,6 +673,267 @@ def load_assumption_register_audit_history(
     return out
 
 
+def insert_valuation_policy_version(conn: sqlite3.Connection, row: dict[str, Any]) -> int:
+    """Append a PM-editable valuation policy version and return its id."""
+    cursor = conn.execute(
+        """
+        INSERT INTO valuation_policy_versions (
+            created_at, actor, global_defaults_json, sector_defaults_json, source_ref, notes
+        ) VALUES (
+            :created_at, :actor, :global_defaults_json, :sector_defaults_json, :source_ref, :notes
+        )
+        """,
+        row,
+    )
+    conn.commit()
+    return int(cursor.lastrowid)
+
+
+def load_latest_valuation_policy_version(conn: sqlite3.Connection) -> dict[str, Any] | None:
+    row = conn.execute(
+        """
+        SELECT id, created_at, actor, global_defaults_json, sector_defaults_json, source_ref, notes
+        FROM valuation_policy_versions
+        ORDER BY id DESC
+        LIMIT 1
+        """
+    ).fetchone()
+    if row is None:
+        return None
+    item = dict(row)
+    item["global_defaults"] = json.loads(item.pop("global_defaults_json") or "{}")
+    item["sector_defaults"] = json.loads(item.pop("sector_defaults_json") or "{}")
+    return item
+
+
+def upsert_damodaran_policy_drafts(conn: sqlite3.Connection, rows: list[dict[str, Any]]) -> int:
+    """Upsert parsed Damodaran drop-folder rows as reviewable drafts."""
+    if not rows:
+        return 0
+    payload: list[dict[str, Any]] = []
+    for row in rows:
+        item = dict(row)
+        item["raw_json"] = json.dumps(item.get("raw") or {}, separators=(",", ":"))
+        payload.append(item)
+    conn.executemany(
+        """
+        INSERT INTO damodaran_policy_drafts (
+            created_at, source_file, source_kind, row_key, field, value, unit,
+            source_date, status, raw_json
+        ) VALUES (
+            :created_at, :source_file, :source_kind, :row_key, :field, :value, :unit,
+            :source_date, :status, :raw_json
+        )
+        ON CONFLICT(source_file, row_key, field) DO UPDATE SET
+            created_at = excluded.created_at,
+            source_kind = excluded.source_kind,
+            value = excluded.value,
+            unit = excluded.unit,
+            source_date = excluded.source_date,
+            raw_json = excluded.raw_json
+        """,
+        payload,
+    )
+    conn.commit()
+    return len(payload)
+
+
+def load_damodaran_policy_drafts(
+    conn: sqlite3.Connection,
+    status: str | None = None,
+    limit: int = 100,
+) -> list[dict[str, Any]]:
+    where = "WHERE status = ?" if status else ""
+    params: list[Any] = [status] if status else []
+    params.append(max(1, int(limit)))
+    rows = conn.execute(
+        f"""
+        SELECT id, created_at, source_file, source_kind, row_key, field, value,
+               unit, source_date, status, raw_json
+        FROM damodaran_policy_drafts
+        {where}
+        ORDER BY created_at DESC, id DESC
+        LIMIT ?
+        """,
+        params,
+    ).fetchall()
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        item = dict(row)
+        item["raw"] = json.loads(item.pop("raw_json") or "{}")
+        out.append(item)
+    return out
+
+
+def insert_pending_assumption_change(conn: sqlite3.Connection, row: dict[str, Any]) -> int:
+    item = dict(row)
+    item["ticker"] = str(item["ticker"]).upper()
+    item["metadata_json"] = json.dumps(item.get("metadata") or {}, separators=(",", ":"))
+    cursor = conn.execute(
+        """
+        INSERT INTO pending_assumption_changes (
+            created_at, updated_at, ticker, assumption_name, current_value, proposed_value,
+            source_type, source_ref, confidence, rationale, citation, status,
+            approval_ref, applied_at, metadata_json
+        ) VALUES (
+            :created_at, :updated_at, :ticker, :assumption_name, :current_value, :proposed_value,
+            :source_type, :source_ref, :confidence, :rationale, :citation, :status,
+            :approval_ref, :applied_at, :metadata_json
+        )
+        """,
+        item,
+    )
+    conn.commit()
+    return int(cursor.lastrowid)
+
+
+def load_pending_assumption_changes(
+    conn: sqlite3.Connection,
+    ticker: str,
+    status: str | None = "pending",
+) -> list[dict[str, Any]]:
+    params: list[Any] = [str(ticker).upper()]
+    where = "WHERE ticker = ?"
+    if status:
+        where += " AND status = ?"
+        params.append(status)
+    rows = conn.execute(
+        f"""
+        SELECT id, created_at, updated_at, ticker, assumption_name, current_value,
+               proposed_value, source_type, source_ref, confidence, rationale,
+               citation, status, approval_ref, applied_at, metadata_json
+        FROM pending_assumption_changes
+        {where}
+        ORDER BY updated_at DESC, id DESC
+        """,
+        params,
+    ).fetchall()
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        item = dict(row)
+        item["metadata"] = json.loads(item.pop("metadata_json") or "{}")
+        item["change_id"] = item.pop("id")
+        out.append(item)
+    return out
+
+
+def apply_pending_assumption_changes(
+    conn: sqlite3.Connection,
+    *,
+    ticker: str,
+    change_ids: list[int],
+    actor: str,
+    applied_at: str,
+    approval_ref: str,
+) -> list[dict[str, Any]]:
+    """Approve selected pending changes and make them active effective entries."""
+    if not change_ids:
+        return []
+    ticker = str(ticker).upper()
+    placeholders = ",".join("?" for _ in change_ids)
+    rows = conn.execute(
+        f"""
+        SELECT id, ticker, assumption_name, proposed_value, source_type, source_ref, metadata_json
+        FROM pending_assumption_changes
+        WHERE ticker = ? AND status = 'pending' AND id IN ({placeholders})
+        ORDER BY id
+        """,
+        [ticker, *change_ids],
+    ).fetchall()
+    approved = [dict(row) for row in rows]
+    if not approved:
+        return []
+    with conn:
+        for row in approved:
+            conn.execute(
+                """
+                UPDATE approved_assumption_entries
+                SET active = 0
+                WHERE ticker = ? AND assumption_name = ? AND active = 1
+                """,
+                [ticker, row["assumption_name"]],
+            )
+            conn.execute(
+                """
+                INSERT INTO approved_assumption_entries (
+                    applied_at, ticker, assumption_name, value, source_type,
+                    source_ref, approval_ref, actor, metadata_json, active
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1)
+                """,
+                [
+                    applied_at,
+                    ticker,
+                    row["assumption_name"],
+                    row["proposed_value"],
+                    row["source_type"],
+                    row["source_ref"],
+                    approval_ref,
+                    actor,
+                    row["metadata_json"] or "{}",
+                ],
+            )
+            conn.execute(
+                """
+                UPDATE pending_assumption_changes
+                SET status = 'approved', updated_at = ?, applied_at = ?, approval_ref = ?
+                WHERE id = ?
+                """,
+                [applied_at, applied_at, approval_ref, row["id"]],
+            )
+    for row in approved:
+        row["metadata"] = json.loads(row.pop("metadata_json") or "{}")
+        row["change_id"] = row.pop("id")
+        row["approval_ref"] = approval_ref
+        row["applied_at"] = applied_at
+    return approved
+
+
+def reject_pending_assumption_changes(
+    conn: sqlite3.Connection,
+    *,
+    ticker: str,
+    change_ids: list[int],
+    actor: str,
+    rejected_at: str,
+) -> int:
+    if not change_ids:
+        return 0
+    placeholders = ",".join("?" for _ in change_ids)
+    cursor = conn.execute(
+        f"""
+        UPDATE pending_assumption_changes
+        SET status = 'rejected', updated_at = ?
+        WHERE ticker = ? AND status = 'pending' AND id IN ({placeholders})
+        """,
+        [rejected_at, str(ticker).upper(), *change_ids],
+    )
+    conn.commit()
+    return int(cursor.rowcount or 0)
+
+
+def load_approved_assumption_entries(conn: sqlite3.Connection, ticker: str) -> list[dict[str, Any]]:
+    rows = conn.execute(
+        """
+        SELECT id, applied_at, ticker, assumption_name, value, source_type, source_ref,
+               approval_ref, actor, metadata_json
+        FROM approved_assumption_entries
+        WHERE ticker = ? AND active = 1
+        ORDER BY applied_at DESC, id DESC
+        """,
+        [str(ticker).upper()],
+    ).fetchall()
+    out: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for row in rows:
+        item = dict(row)
+        if item["assumption_name"] in seen:
+            continue
+        seen.add(item["assumption_name"])
+        item["metadata"] = json.loads(item.pop("metadata_json") or "{}")
+        out.append(item)
+    return out
+
+
 def insert_pipeline_report_archive(conn: sqlite3.Connection, row: dict[str, Any]) -> int:
     """Append a dashboard report snapshot and return its row id."""
     cursor = conn.execute(

--- a/db/loader.py
+++ b/db/loader.py
@@ -1457,3 +1457,55 @@ def insert_dossier_note_block(conn: sqlite3.Connection, row: dict[str, Any]) -> 
     )
     conn.commit()
     return int(cursor.lastrowid)
+
+
+# ---------------------------------------------------------------------------
+# Convenience helpers — used by valuation layer (stage_02) to avoid importing
+# stage_04 pipeline modules.
+# ---------------------------------------------------------------------------
+
+def get_valuation_policy_rf_erp() -> tuple[float, float]:
+    """Return (risk_free_rate, equity_risk_premium) from the latest saved policy.
+
+    Falls back to (0.045, 0.05) if no policy has been saved yet.
+    """
+    try:
+        from db.schema import create_tables, get_connection
+        with get_connection() as conn:
+            create_tables(conn)
+            row = load_latest_valuation_policy_version(conn)
+    except Exception:
+        row = None
+    if not row:
+        return 0.045, 0.05
+    g = row.get("global_defaults") or {}
+    rf = float(g.get("risk_free_rate", 0.045))
+    erp = float(g.get("equity_risk_premium", 0.05))
+    return rf, erp
+
+
+def get_valuation_policy_sector_defaults(sector: str) -> dict[str, float]:
+    """Return saved sector-level defaults for *sector*, or {} if none saved."""
+    try:
+        from db.schema import create_tables, get_connection
+        with get_connection() as conn:
+            create_tables(conn)
+            row = load_latest_valuation_policy_version(conn)
+    except Exception:
+        row = None
+    if not row:
+        return {}
+    sector_map: dict[str, dict[str, float]] = row.get("sector_defaults") or {}
+    return dict(sector_map.get(sector) or {})
+
+
+def get_approved_assumption_overrides(ticker: str) -> dict[str, float]:
+    """Return active approved assumption overrides for *ticker* as {name: value}."""
+    try:
+        from db.schema import create_tables, get_connection
+        with get_connection() as conn:
+            create_tables(conn)
+            rows = load_approved_assumption_entries(conn, ticker)
+    except Exception:
+        return {}
+    return {row["assumption_name"]: float(row["value"]) for row in rows}

--- a/db/loader.py
+++ b/db/loader.py
@@ -3,6 +3,7 @@ Alpha Pod — Database Loader
 Insert/update functions for all tables. All operations are idempotent (upsert).
 """
 import sqlite3
+import json
 from typing import Any
 
 from src.utils import utc_now_iso
@@ -584,6 +585,92 @@ def insert_valuation_override_audit(conn: sqlite3.Connection, rows: list[dict[st
         rows,
     )
     conn.commit()
+
+
+def _split_assumption_register_diff(row: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
+    prior: dict[str, Any] = {}
+    new: dict[str, Any] = {}
+    for field, change in (row.get("changed_fields") or {}).items():
+        if not isinstance(change, dict):
+            continue
+        prior[field] = change.get("prior")
+        new[field] = change.get("new")
+    return prior, new
+
+
+def insert_assumption_register_audit(conn: sqlite3.Connection, rows: list[dict[str, Any]]) -> None:
+    """Append review-relevant Assumption Register audit events."""
+    if not rows:
+        return
+
+    payload: list[dict[str, Any]] = []
+    for row in rows:
+        item = dict(row)
+        prior, new = _split_assumption_register_diff(item)
+        item["ticker"] = str(item["ticker"]).upper()
+        item["entity_type"] = (
+            item["entity_type"].value
+            if hasattr(item.get("entity_type"), "value")
+            else str(item.get("entity_type"))
+        )
+        item["prior_diff_json"] = json.dumps(prior, separators=(",", ":"))
+        item["new_diff_json"] = json.dumps(new, separators=(",", ":"))
+        item["changed_fields_json"] = json.dumps(item.get("changed_fields") or {}, separators=(",", ":"))
+        item["valuation_impact_json"] = (
+            json.dumps(item.get("valuation_impact"), separators=(",", ":"))
+            if item.get("valuation_impact") is not None
+            else None
+        )
+        payload.append(item)
+
+    conn.executemany(
+        """
+        INSERT INTO assumption_register_audit (
+            event_ts, actor, actor_type, entity_type, entity_id, ticker,
+            assumption_name, scope, event_type, prior_diff_json, new_diff_json,
+            changed_fields_json, valuation_impact_json, reason
+        ) VALUES (
+            :event_ts, :actor, :actor_type, :entity_type, :entity_id, :ticker,
+            :assumption_name, :scope, :event_type, :prior_diff_json, :new_diff_json,
+            :changed_fields_json, :valuation_impact_json, :reason
+        )
+        """,
+        payload,
+    )
+    conn.commit()
+
+
+def load_assumption_register_audit_history(
+    conn: sqlite3.Connection,
+    ticker: str,
+    limit: int = 50,
+) -> list[dict[str, Any]]:
+    """Load Assumption Register audit history separately from PM override audit."""
+    rows = conn.execute(
+        """
+        SELECT event_ts, actor, actor_type, entity_type, entity_id, ticker,
+               assumption_name, scope, event_type, prior_diff_json, new_diff_json,
+               changed_fields_json, valuation_impact_json, reason
+        FROM assumption_register_audit
+        WHERE ticker = ?
+        ORDER BY event_ts DESC, id DESC
+        LIMIT ?
+        """,
+        [str(ticker).upper(), max(1, int(limit))],
+    ).fetchall()
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        item = dict(row)
+        item["prior_diff"] = json.loads(item["prior_diff_json"] or "{}")
+        item["new_diff"] = json.loads(item["new_diff_json"] or "{}")
+        item["changed_fields"] = json.loads(item["changed_fields_json"] or "{}")
+        item["valuation_impact"] = (
+            json.loads(item["valuation_impact_json"])
+            if item.get("valuation_impact_json")
+            else None
+        )
+        out.append(item)
+    return out
 
 
 def insert_pipeline_report_archive(conn: sqlite3.Connection, row: dict[str, Any]) -> int:

--- a/db/schema.py
+++ b/db/schema.py
@@ -367,6 +367,64 @@ def create_tables(conn: sqlite3.Connection | None = None):
         reason                TEXT
     );
 
+    CREATE TABLE IF NOT EXISTS valuation_policy_versions (
+        id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+        created_at            TEXT NOT NULL,
+        actor                 TEXT NOT NULL,
+        global_defaults_json  TEXT NOT NULL,
+        sector_defaults_json  TEXT NOT NULL,
+        source_ref            TEXT,
+        notes                 TEXT
+    );
+
+    CREATE TABLE IF NOT EXISTS damodaran_policy_drafts (
+        id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+        created_at            TEXT NOT NULL,
+        source_file           TEXT NOT NULL,
+        source_kind           TEXT NOT NULL,
+        row_key               TEXT NOT NULL,
+        field                 TEXT NOT NULL,
+        value                 REAL NOT NULL,
+        unit                  TEXT,
+        source_date           TEXT,
+        status                TEXT NOT NULL DEFAULT 'draft',
+        raw_json              TEXT NOT NULL,
+        UNIQUE(source_file, row_key, field)
+    );
+
+    CREATE TABLE IF NOT EXISTS pending_assumption_changes (
+        id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+        created_at            TEXT NOT NULL,
+        updated_at            TEXT NOT NULL,
+        ticker                TEXT NOT NULL,
+        assumption_name       TEXT NOT NULL,
+        current_value         REAL,
+        proposed_value        REAL NOT NULL,
+        source_type           TEXT NOT NULL,
+        source_ref            TEXT NOT NULL,
+        confidence            TEXT,
+        rationale             TEXT,
+        citation              TEXT,
+        status                TEXT NOT NULL DEFAULT 'pending',
+        approval_ref          TEXT,
+        applied_at            TEXT,
+        metadata_json         TEXT NOT NULL DEFAULT '{}'
+    );
+
+    CREATE TABLE IF NOT EXISTS approved_assumption_entries (
+        id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+        applied_at            TEXT NOT NULL,
+        ticker                TEXT NOT NULL,
+        assumption_name       TEXT NOT NULL,
+        value                 REAL NOT NULL,
+        source_type           TEXT NOT NULL,
+        source_ref            TEXT NOT NULL,
+        approval_ref          TEXT NOT NULL,
+        actor                 TEXT NOT NULL,
+        metadata_json         TEXT NOT NULL DEFAULT '{}',
+        active                INTEGER NOT NULL DEFAULT 1
+    );
+
     CREATE TABLE IF NOT EXISTS agent_run_cache (
         ticker          TEXT NOT NULL,
         agent_name      TEXT NOT NULL,
@@ -772,6 +830,10 @@ def create_tables(conn: sqlite3.Connection | None = None):
     CREATE INDEX IF NOT EXISTS idx_override_audit_ticker_ts ON valuation_override_audit(ticker, event_ts DESC);
     CREATE INDEX IF NOT EXISTS idx_assumption_register_audit_ticker_ts ON assumption_register_audit(ticker, event_ts DESC);
     CREATE INDEX IF NOT EXISTS idx_assumption_register_audit_field_ts ON assumption_register_audit(ticker, assumption_name, event_ts DESC);
+    CREATE INDEX IF NOT EXISTS idx_valuation_policy_versions_created ON valuation_policy_versions(created_at DESC);
+    CREATE INDEX IF NOT EXISTS idx_damodaran_policy_drafts_status ON damodaran_policy_drafts(status, created_at DESC);
+    CREATE INDEX IF NOT EXISTS idx_pending_assumption_changes_ticker_status ON pending_assumption_changes(ticker, status, updated_at DESC);
+    CREATE INDEX IF NOT EXISTS idx_approved_assumption_entries_ticker_active ON approved_assumption_entries(ticker, active, applied_at DESC);
     CREATE INDEX IF NOT EXISTS idx_agent_run_log_ticker_ts ON agent_run_log(ticker, run_ts DESC);
     CREATE INDEX IF NOT EXISTS idx_agent_run_cache_lookup ON agent_run_cache(ticker, agent_name, input_hash, model, prompt_hash);
     CREATE INDEX IF NOT EXISTS idx_agent_run_artifacts_ticker_agent_ts ON agent_run_artifacts(ticker, agent_name, created_at DESC);

--- a/db/schema.py
+++ b/db/schema.py
@@ -349,6 +349,24 @@ def create_tables(conn: sqlite3.Connection | None = None):
         proposed_expected_iv         REAL
     );
 
+    CREATE TABLE IF NOT EXISTS assumption_register_audit (
+        id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+        event_ts              TEXT NOT NULL,
+        actor                 TEXT NOT NULL,
+        actor_type            TEXT NOT NULL,
+        entity_type           TEXT NOT NULL,
+        entity_id             TEXT NOT NULL,
+        ticker                TEXT NOT NULL,
+        assumption_name       TEXT NOT NULL,
+        scope                 TEXT NOT NULL,
+        event_type            TEXT NOT NULL,
+        prior_diff_json       TEXT NOT NULL,
+        new_diff_json         TEXT NOT NULL,
+        changed_fields_json   TEXT NOT NULL,
+        valuation_impact_json TEXT,
+        reason                TEXT
+    );
+
     CREATE TABLE IF NOT EXISTS agent_run_cache (
         ticker          TEXT NOT NULL,
         agent_name      TEXT NOT NULL,
@@ -752,6 +770,8 @@ def create_tables(conn: sqlite3.Connection | None = None):
     CREATE INDEX IF NOT EXISTS idx_company_text_lookup ON company_text_cache(ticker, text_type, updated_at);
     CREATE INDEX IF NOT EXISTS idx_peer_similarity_lookup ON peer_similarity_cache(target_ticker, peer_ticker, embedding_model);
     CREATE INDEX IF NOT EXISTS idx_override_audit_ticker_ts ON valuation_override_audit(ticker, event_ts DESC);
+    CREATE INDEX IF NOT EXISTS idx_assumption_register_audit_ticker_ts ON assumption_register_audit(ticker, event_ts DESC);
+    CREATE INDEX IF NOT EXISTS idx_assumption_register_audit_field_ts ON assumption_register_audit(ticker, assumption_name, event_ts DESC);
     CREATE INDEX IF NOT EXISTS idx_agent_run_log_ticker_ts ON agent_run_log(ticker, run_ts DESC);
     CREATE INDEX IF NOT EXISTS idx_agent_run_cache_lookup ON agent_run_cache(ticker, agent_name, input_hash, model, prompt_hash);
     CREATE INDEX IF NOT EXISTS idx_agent_run_artifacts_ticker_agent_ts ON agent_run_artifacts(ticker, agent_name, created_at DESC);

--- a/docs/design-docs/valuation-methodology-critical-review-and-action-plan.md
+++ b/docs/design-docs/valuation-methodology-critical-review-and-action-plan.md
@@ -110,6 +110,13 @@ The critique remains valid because the docs do not define enough policy around:
 
 The `assumption_register` should be the first real contract.
 
+Implementation status, 2026-05-11: V1 shipped as a deterministic executable contract in
+`src/contracts/assumption_register.py` and `src/stage_02_valuation/assumption_register.py`.
+It now emits numeric effective ticker assumptions, WACC components, terminal value drivers,
+model trust state, compact flagged summaries, and separate assumption-register audit rows.
+The remaining richer range policy, source quality state, LLM advisory attachment, sector/global
+policy entries, and automatic sensitivity-driven impact scoring remain V2 work.
+
 Draft Pydantic shape:
 
 ```python

--- a/docs/plans/2026-05-06-assumption-register-contract.md
+++ b/docs/plans/2026-05-06-assumption-register-contract.md
@@ -1,710 +1,280 @@
 # Assumption Register Contract Implementation Plan
 
-> **For Claude:** REQUIRED SUB-SKILL: Use executing-plans to implement this plan task-by-task.
+## Summary
 
-**Goal:** Build a typed `AssumptionRegister` that attaches to every valuation run, records each DCF driver with its source, accepted range, and flag level, and surfaces that register through the batch runner, JSON exporter, and override workbench.
+Build the first executable assumption-register layer for Alpha Pod.
 
-**Architecture:** A new `assumption_register.py` module defines the Pydantic contracts (`AssumptionRegisterEntry`, `AssumptionRegister`) and the range-rule table. `build_assumption_register()` takes a completed `ValuationInputsWithLineage` and produces a register. The batch runner populates it after `build_valuation_inputs()` and passes it to the JSON exporter. The override workbench reads it so the dashboard can surface flags. No LLM touches this path — it is entirely deterministic.
+V1 is intentionally narrow:
 
-**Tech Stack:** Python 3.13, Pydantic v2 (already a dep via FastAPI), existing `valuation_types.py` dataclass pattern, pytest.
+- numeric ticker-level DCF drivers only
+- deterministic-only population
+- flag-only validation, no valuation blocking
+- global contract available to all stages
+- stage 02 builder populates the register from valuation inputs
+- append-only audit table captures material events
 
----
+This is the foundation for later LLM advisory inputs, Damodaran data, WACC policy inputs, and richer industry/company-specific range rules.
 
-## Task 1: Define the contracts in `assumption_register.py`
+## Decisions
 
-**Files:**
-- Create: `src/stage_02_valuation/assumption_register.py`
-- Test: `tests/test_assumption_register.py`
+- Contract location: define shared types in `src/contracts/assumption_register.py`.
+- Builder location: build valuation-specific entries in `src/stage_02_valuation/assumption_register.py`.
+- Contract boundary: Pydantic models define the public boundary; stage 02 may build lightweight dict payloads internally and validate once into `AssumptionRegister`.
+- V1 scope: populate ticker-level DCF driver assumptions only.
+- Future scope: contract may represent ticker, sector, industry, and global identities, but sector/global policy population is V2.
+- Entity identity: V1 entries represent effective ticker assumptions, so populated entries use `entity_type="ticker"` even when source lineage points to sector/global defaults or overrides.
+- Value types: numeric only in V1; reserve `value_type="numeric"` for future compatibility.
+- Scenarios: V1 does not add scenario probabilities or context scenario outputs to the register; scenario assumption packs are V2.
+- Terminal value: terminal value drivers are first-class V1 assumption entries; terminal concentration and computed terminal values remain diagnostics.
+- LLMs: no LLM or agent output populates or mutates the register in V1.
+- Future LLM work: V2 connects `driver_assessments.py` and judgment agents as advisory inputs.
+- Advisory reserve: V1 reserves neutral advisory attachment fields, but leaves them empty and does not import `driver_assessments.py` workflow states into the official contract.
+- Ranges: static fallback ranges in V1; historical, industry, and scale-aware rules are V2.
+- Flags: out-of-range values flag for review but do not block valuation.
+- Flag semantics: V1 defines deterministic meanings for `none`, `watch`, `review_required`, and `critical`; flags are severity labels, not PM approval state.
+- Model trust: out-of-range and critical flags do not block computation or export in V1, but they must downgrade the valuation's review/trust state on ranked and dossier/export surfaces.
+- Model trust rollup: derive `model_trust_state` from max assumption flag level plus selected valuation diagnostics such as terminal concentration or mathematically dangerous guardrails.
+- Approval: register displays approval state, but durable truth remains in PM override and audit records.
+- Approval granularity: PM approval is value-specific; material value changes make approval stale or review-needed.
+- Approval references: `approval_ref` points only to durable PM-applied audit rows, such as `valuation_override_audit` or `wacc_methodology_audit`; pending recommendation files belong in `advisory_refs`.
+- WACC treatment: final WACC and its material cost-of-capital components are first-class assumption entries in V1.
+- WACC approval staleness: assess staleness at the component level; material movement in beta, ERP, size premium, cost of debt, weights, or methodology can make that component stale even when final WACC moves less than 25 bps.
+- Naming discipline: V1 uses stable field keys and controlled stage/scope/forecast-line vocabularies so register entries are filterable and testable.
+- Accepted ranges: V1 range rules are PM-review ranges for effective values, not necessarily the same as input-assembly hard clamps.
+- Materiality rules: keep provisional thresholds in a centralized table near the builder/diff logic rather than scattered inline conditionals.
+- Audit: append material events only, not every generated assumption on every run.
+- First-seen audit: log first-seen events only for review-relevant entries in V1; the full generated baseline remains in valuation JSON, not the audit table.
+- Audit payloads: store concise prior/new diffs for changed fields, not full entry snapshots or full-register snapshots.
+- Valuation impact: optional in entries; required only for override preview/apply paths.
+- Automatic impact scoring: V1 does not run per-assumption what-if DCFs for every flagged entry; broader sensitivity-driven impact scoring is V2.
+- Exports: full register in valuation JSON; compact flagged summary in ticker dossier V1.
+- Compact summary: dossier/export/ranking summaries include trust state, flag counts, max flag, and flagged entries only; clean assumptions stay in the full valuation JSON register.
+- API audit families: expose existing PM override audit and new assumption-register audit as separate payload keys in V1.
 
-**Step 1: Write the failing test**
+## Contract Shape
 
-```python
-# tests/test_assumption_register.py
-from src.stage_02_valuation.assumption_register import (
-    AssumptionOwner,
-    FlagLevel,
-    AssumptionRegisterEntry,
-    AssumptionRegister,
-)
+Create shared Pydantic v2 models under `src/contracts/assumption_register.py`.
 
-def test_entry_in_range_has_no_flag():
-    e = AssumptionRegisterEntry(
-        assumption_name="revenue_growth_near",
-        proposed_value=0.08,
-        accepted_low=0.02,
-        accepted_high=0.20,
-        range_rule_id="revenue_growth_default",
-        source="yfinance_cagr_3yr",
-        flag_level=FlagLevel.none,
-        owner=AssumptionOwner.deterministic,
-    )
-    assert e.flag_level == FlagLevel.none
-    assert e.out_of_range is False
+Core enums:
 
-def test_entry_out_of_range_detected():
-    e = AssumptionRegisterEntry(
-        assumption_name="ebit_margin_start",
-        proposed_value=0.55,
-        accepted_low=0.05,
-        accepted_high=0.40,
-        range_rule_id="ebit_margin_default",
-        source="yfinance",
-        flag_level=FlagLevel.review_required,
-        owner=AssumptionOwner.deterministic,
-    )
-    assert e.out_of_range is True
+- `AssumptionEntityType`: `ticker`, `sector`, `industry`, `global`
+- `AssumptionOwner`: `deterministic`, `pm_override`, `system_flag`
+- `AssumptionApprovalState`: `none`, `review_required`, `pm_approved`, `rejected`, `stale_approval`
+- `FlagLevel`: `none`, `watch`, `review_required`, `critical`
+- `AssumptionValueType`: `numeric`
 
-def test_register_holds_entries_and_counts_flags():
-    entries = [
-        AssumptionRegisterEntry(
-            assumption_name="revenue_growth_near",
-            proposed_value=0.08,
-            accepted_low=0.02,
-            accepted_high=0.20,
-            range_rule_id="revenue_growth_default",
-            source="yfinance_cagr_3yr",
-            flag_level=FlagLevel.none,
-            owner=AssumptionOwner.deterministic,
-        ),
-        AssumptionRegisterEntry(
-            assumption_name="ebit_margin_start",
-            proposed_value=0.55,
-            accepted_low=0.05,
-            accepted_high=0.40,
-            range_rule_id="ebit_margin_default",
-            source="yfinance",
-            flag_level=FlagLevel.review_required,
-            owner=AssumptionOwner.deterministic,
-        ),
-    ]
-    reg = AssumptionRegister(ticker="AAPL", entries=entries)
-    assert reg.flag_count(FlagLevel.review_required) == 1
-    assert reg.flag_count(FlagLevel.none) == 1
-    assert reg.has_critical is False
+Owner semantics:
+
+- `deterministic`: official value is owned by deterministic data/config/model logic.
+- `pm_override`: official value is owned by a PM-approved override, regardless of whether the idea originated from manual review or an advisory agent.
+- `system_flag`: entry is generated to surface a system diagnostic or guardrail rather than a PM-authored value.
+
+Detailed provenance remains in `source_lineage`, `approval_ref`, and `advisory_refs`; `owner` should not encode source strings such as `override_ticker`, `qoe_llm_approved`, or `story_profile`.
+
+Naming conventions:
+
+- `assumption_name`: machine-stable key matching `ForecastDrivers` or WACC input names where possible, such as `revenue_growth_near`, `ebit_margin_target`, `wacc`, `beta_relevered`, or `exit_multiple`.
+- `stage`: controlled workflow location; V1 values are `input_assembly`, `wacc`, `dcf`, and `terminal_value`.
+- `scope`: PM-facing grouping; V1 values are `growth`, `margin`, `tax`, `working_capital`, `reinvestment`, `wacc`, `terminal_value`, and `capital_structure`.
+- `affected_forecast_lines`: stable line names; V1 values include `revenue`, `ebit`, `nopat`, `fcff`, `terminal_value`, `enterprise_value`, and `equity_value`.
+
+Flag-level semantics:
+
+- `none`: value is inside accepted range and has no review-state issue.
+- `watch`: value is near a boundary or has a weak deterministic diagnostic, but is still usable.
+- `review_required`: value is outside accepted range, approval is stale, source/range/owner changed materially, or PM review is required before trust improves.
+- `critical`: value or diagnostic is mathematically dangerous or valuation-trust dangerous, such as impossible values, terminal denominator failure, terminal growth above guardrail, or WACC-method disagreement above the critical threshold.
+
+Core entry fields:
+
+- `entity_type`
+- `entity_id`
+- `ticker`
+- `assumption_name`
+- `scope`
+- `stage`
+- `value_type`
+- `current_value`
+- `accepted_low`
+- `accepted_high`
+- `range_rule_id`
+- `range_rule_description`
+- `source_lineage`
+- `affected_forecast_lines`
+- `flag_level`
+- `owner`
+- `approval_state`
+- `approval_ref`
+- `out_of_range`
+- `valuation_impact`
+- `evidence_refs`
+- `advisory_refs`
+- `notes`
+
+Register fields:
+
+- `ticker`
+- `generated_at`
+- `entries`
+- `flag_counts`
+- `max_flag_level`
+- `has_critical`
+- `model_trust_state`
+- `summary`
+
+Model trust semantics:
+
+- `clean`: no assumption flags above `none` and no major valuation diagnostics.
+- `watch`: max flag is `watch` or terminal concentration is elevated but not dangerous.
+- `review_required`: max flag is `review_required`, stale approval exists, or major diagnostics such as `tv_high_flag` fire.
+- `critical_review_required`: max flag is `critical` or mathematically dangerous diagnostics fire.
+
+## Implementation
+
+Execution requirements:
+
+- Use relevant skills before implementation. Start with `executing-plans`; use `requesting-code-review` before final handoff.
+- Use `rtk` for Git, test, and repo-inspection commands where available.
+- Read `AGENTS.md`, `.agent/session-state.md`, and this plan before changing code.
+- Keep `course/` and other unrelated untracked local artifacts out of the branch.
+- Preserve the deterministic/LLM boundary: no LLM or advisory output may mutate official valuation inputs except through the PM-approved override path.
+- Ship V1 as one coherent PR with internally sliced commits/checkpoints rather than multiple partially wired PRs.
+
+1. Add shared contracts.
+   - Create `src/contracts/__init__.py` if needed.
+   - Add `src/contracts/assumption_register.py`.
+   - Keep this module free of stage 02 imports.
+
+2. Add stage 02 builder.
+   - Create `src/stage_02_valuation/assumption_register.py`.
+   - Build entries from `ForecastDrivers` and `source_lineage`.
+   - Use lightweight internal payload construction if helpful, then validate once against `AssumptionRegister` at the contract boundary.
+   - Cover the core numeric DCF drivers already shown in the assumptions workbench.
+   - Cover terminal value drivers: `revenue_growth_terminal`, `ronic_terminal`, `exit_multiple`, `terminal_blend_gordon_weight`, and `terminal_blend_exit_weight`.
+   - Cover WACC assumption inputs from `wacc_inputs`, including final WACC, risk-free rate, equity risk premium, beta, size premium, cost of debt, equity/debt weights, and selected methodology where available.
+   - Populate V1 entries as effective ticker assumptions; preserve sector/global origins in lineage/scope without creating sector/global policy rows.
+   - Use static fallback `RANGE_RULES`.
+   - Do not simply mirror `_bounded()` hard clamps as accepted ranges when the PM-review range should be narrower or differently described.
+   - If raw/pre-clamp evidence is readily available, mention it in `evidence_refs` or `notes`; do not add a V1 `raw_value` field.
+   - Mark `owner=pm_override` when source lineage or override state indicates an approved override; keep detailed origin in lineage and references.
+
+3. Add materiality and diff logic.
+   - Define centralized `MATERIALITY_RULES` keyed by field class, scope, or explicit assumption name.
+   - Implement field-class thresholds for V1:
+     - WACC: 25 bps
+     - WACC components: 25 bps for rate components, 0.10 beta points for beta, 5 percentage points for capital structure weights, any selected-methodology change
+     - other percentage drivers: 50 bps
+     - multiples: 0.5x
+     - working-capital days: 5 days
+     - money fields: greater of USD 10m or 1% of revenue base
+   - Always treat flag, source, owner, approval, and range-rule changes as material.
+   - Document these thresholds as provisional.
+
+4. Add append-only audit.
+   - Add `assumption_register_audit` to `db/schema.py`.
+   - Add insert/list helpers to `db/loader.py` or a focused stage 04 helper.
+   - Log only material events:
+     - first seen when the entry is review-relevant
+     - value materially changed
+     - flag changed
+     - source changed
+     - owner or approval state changed
+     - range rule changed
+     - PM override applied or removed
+   - Include `event_ts`, `actor`, `actor_type`, `entity_type`, `entity_id`, `ticker`, `assumption_name`, `scope`, `event_type`, prior/new diff JSON, optional valuation impact, and reason.
+   - Keep audit rows concise; do not duplicate the full register or full entry payload in every audit row.
+
+5. Wire valuation outputs.
+   - In `batch_runner.value_single_ticker()`, attach `assumption_register_json`.
+   - In `json_exporter`, add top-level `assumption_register`.
+   - In `dcf_audit` or workspace views, expose a compact flag summary where useful.
+
+6. Wire workbench and API.
+   - Extend `override_workbench.build_override_workbench()` with `assumption_register`.
+   - Add assumption-register audit rows to the valuation assumptions payload as `assumption_register_audit_rows`.
+   - Preserve existing override audit rows separately as `override_audit_rows`; keep legacy `audit_rows` only as a compatibility alias if needed.
+   - Preserve existing `valuation_overrides.yaml` as the official PM write path.
+   - On override preview/apply, compute and store optional valuation-impact metadata.
+   - Do not compute automatic per-flag valuation impact outside preview/apply paths in V1.
+
+7. Wire dossier/export summary.
+   - Keep full register in valuation JSON.
+   - Add compact summary to ticker dossier/export surfaces:
+     - max flag
+     - flag counts
+     - model trust state
+     - flagged entries only
+   - Do not include clean-but-important assumptions in the compact V1 summary; use full valuation JSON for drill-down.
+   - Preserve deterministic output rows for flagged valuations, but make review-required or critical-review-required trust state visible in ranking/export payloads.
+
+8. Update docs.
+   - Mark the critical-review memo's P0 assumption-register item as implemented once shipped.
+   - Add V2 notes for:
+     - LLM advisory attachment through `driver_assessments.py`
+     - population of reserved `advisory_refs`
+     - scale-aware materiality
+     - history/industry/Damodaran range rules
+     - sector/global policy population
+
+## Tests
+
+Add or extend:
+
+- `tests/test_assumption_register.py`
+- `tests/test_api_contracts.py`
+- `tests/test_batch_runner_professional.py`
+- `tests/test_json_exporter.py`
+- `tests/test_override_workbench.py`
+- `tests/test_ticker_dossier_contract_runtime.py`
+
+Required cases:
+
+- contract JSON round-trip
+- builder validates the final payload against the shared Pydantic contract
+- deterministic builder creates numeric ticker-level entries
+- terminal value drivers are included as assumption entries while terminal outputs remain diagnostics
+- naming conventions are enforced for assumption_name, stage, scope, and affected_forecast_lines
+- static range flags out-of-range values
+- flag levels follow deterministic semantics for none/watch/review_required/critical
+- out-of-range values do not block valuation
+- out-of-range or critical values downgrade `model_trust_state`
+- model trust state rolls up assumption flags plus selected valuation diagnostics
+- material diff logic ignores tiny changes
+- material diff logic logs source/flag/approval changes
+- materiality thresholds are centralized and covered by field-class tests
+- audit rows store concise prior/new diffs rather than full entry snapshots
+- PM approval is value-specific
+- stale approval is surfaced after material value change
+- valuation result includes `assumption_register_json`
+- JSON export includes full `assumption_register`
+- assumptions API payload includes register and audit rows
+- assumptions API payload keeps override and assumption-register audit families separate
+- override preview/apply paths can include valuation-impact metadata
+- ticker dossier/export includes compact flagged summary
+
+Focused verification command:
+
+```powershell
+python -m pytest tests/test_assumption_register.py tests/test_api_contracts.py tests/test_batch_runner_professional.py tests/test_json_exporter.py tests/test_override_workbench.py tests/test_ticker_dossier_contract_runtime.py -q
 ```
 
-**Step 2: Run test to verify it fails**
-
-```
-pytest tests/test_assumption_register.py -x -q
-```
-Expected: ImportError — module does not exist yet.
-
-**Step 3: Implement the contracts**
-
-Create `src/stage_02_valuation/assumption_register.py`:
-
-```python
-"""Typed assumption register contract for deterministic valuation runs."""
-from __future__ import annotations
-
-from enum import Enum
-from typing import Any
-
-from pydantic import BaseModel, Field, model_validator
-
-
-class AssumptionOwner(str, Enum):
-    deterministic = "deterministic"
-    pm_override = "pm_override"
-    blocked = "blocked"
-
-
-class FlagLevel(str, Enum):
-    none = "none"
-    watch = "watch"
-    review_required = "review_required"
-    critical = "critical"
-
-
-_FLAG_RANK = {
-    FlagLevel.none: 0,
-    FlagLevel.watch: 1,
-    FlagLevel.review_required: 2,
-    FlagLevel.critical: 3,
-}
-
-
-class AssumptionRegisterEntry(BaseModel):
-    assumption_name: str
-    proposed_value: float
-    accepted_low: float
-    accepted_high: float
-    range_rule_id: str
-    source: str
-    flag_level: FlagLevel
-    owner: AssumptionOwner
-    notes: str = ""
-
-    @property
-    def out_of_range(self) -> bool:
-        return not (self.accepted_low <= self.proposed_value <= self.accepted_high)
-
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "assumption_name": self.assumption_name,
-            "proposed_value": self.proposed_value,
-            "accepted_low": self.accepted_low,
-            "accepted_high": self.accepted_high,
-            "range_rule_id": self.range_rule_id,
-            "source": self.source,
-            "flag_level": self.flag_level.value,
-            "owner": self.owner.value,
-            "out_of_range": self.out_of_range,
-            "notes": self.notes,
-        }
-
-
-class AssumptionRegister(BaseModel):
-    ticker: str
-    entries: list[AssumptionRegisterEntry] = Field(default_factory=list)
-
-    def flag_count(self, level: FlagLevel) -> int:
-        return sum(1 for e in self.entries if e.flag_level == level)
-
-    @property
-    def has_critical(self) -> bool:
-        return any(e.flag_level == FlagLevel.critical for e in self.entries)
-
-    @property
-    def max_flag_level(self) -> FlagLevel:
-        if not self.entries:
-            return FlagLevel.none
-        return max(self.entries, key=lambda e: _FLAG_RANK[e.flag_level]).flag_level
-
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "ticker": self.ticker,
-            "max_flag_level": self.max_flag_level.value,
-            "has_critical": self.has_critical,
-            "flag_counts": {lvl.value: self.flag_count(lvl) for lvl in FlagLevel},
-            "entries": [e.to_dict() for e in self.entries],
-        }
-```
-
-**Step 4: Run tests**
-
-```
-pytest tests/test_assumption_register.py -x -q
-```
-Expected: 3 passed.
-
-**Step 5: Commit**
-
-```bash
-git add src/stage_02_valuation/assumption_register.py tests/test_assumption_register.py
-git commit -m "feat: add AssumptionRegister and AssumptionRegisterEntry contracts"
-```
-
----
-
-## Task 2: Add the range-rule table and flag computation
-
-**Files:**
-- Modify: `src/stage_02_valuation/assumption_register.py`
-- Modify: `tests/test_assumption_register.py`
-
-The range-rule table encodes the P0 #2 defaults from the action plan. Each rule maps a metric name to `(accepted_low, accepted_high, rule_id)`. Ranges are expressed as fractions (not percent) for margin/growth; raw values for multiples and days.
-
-**Step 1: Add tests for range-rule lookup and `_flag_for_value()`**
-
-Add to `tests/test_assumption_register.py`:
-
-```python
-from src.stage_02_valuation.assumption_register import flag_for_value, RANGE_RULES
-
-def test_flag_for_value_in_range():
-    assert flag_for_value(0.08, 0.02, 0.20) == FlagLevel.none
-
-def test_flag_for_value_watch_boundary():
-    # Just outside — watch, not review_required
-    assert flag_for_value(0.21, 0.02, 0.20) == FlagLevel.watch
-
-def test_flag_for_value_far_out_of_range():
-    # >2× the width outside → review_required
-    assert flag_for_value(0.60, 0.02, 0.20) == FlagLevel.review_required
-
-def test_range_rules_covers_core_drivers():
-    for key in ("revenue_growth_near", "ebit_margin_start", "tax_rate_start",
-                "capex_pct_start", "da_pct_start", "wacc", "exit_multiple"):
-        assert key in RANGE_RULES, f"Missing range rule for {key}"
-```
-
-**Step 2: Run tests to verify they fail**
-
-```
-pytest tests/test_assumption_register.py -x -q
-```
-Expected: ImportError on `flag_for_value, RANGE_RULES`.
-
-**Step 3: Implement range rules and flag logic**
-
-Add to `src/stage_02_valuation/assumption_register.py` (before the `AssumptionRegisterEntry` class):
-
-```python
-# (low, high, rule_id)
-RANGE_RULES: dict[str, tuple[float, float, str]] = {
-    "revenue_growth_near":   (0.00,  0.30, "revenue_growth_default"),
-    "revenue_growth_mid":    (-0.02, 0.20, "revenue_growth_mid_default"),
-    "ebit_margin_start":     (0.00,  0.45, "ebit_margin_default"),
-    "ebit_margin_target":    (0.00,  0.50, "ebit_margin_target_default"),
-    "tax_rate_start":        (0.10,  0.35, "tax_rate_default"),
-    "tax_rate_target":       (0.10,  0.35, "tax_rate_default"),
-    "capex_pct_start":       (0.01,  0.20, "capex_pct_default"),
-    "capex_pct_target":      (0.01,  0.15, "capex_pct_target_default"),
-    "da_pct_start":          (0.01,  0.15, "da_pct_default"),
-    "da_pct_target":         (0.01,  0.12, "da_pct_target_default"),
-    "dso_start":             (10.0, 120.0, "dso_default"),
-    "dio_start":             (0.0,  180.0, "dio_default"),
-    "dpo_start":             (10.0, 120.0, "dpo_default"),
-    "wacc":                  (0.05,  0.18, "wacc_default"),
-    "exit_multiple":         (4.0,   25.0, "exit_multiple_default"),
-    "ronic_terminal":        (0.04,  0.20, "ronic_terminal_default"),
-    "terminal_blend_gordon_weight": (0.0, 1.0, "blend_weight_default"),
-}
-
-
-def flag_for_value(value: float, low: float, high: float) -> FlagLevel:
-    """Deterministic flag from range bounds. Watch = just outside, review_required = far outside."""
-    if low <= value <= high:
-        return FlagLevel.none
-    width = high - low
-    distance = min(abs(value - low), abs(value - high))
-    if distance <= 0.10 * width + 1e-9:
-        return FlagLevel.watch
-    return FlagLevel.review_required
-```
-
-**Step 4: Run tests**
-
-```
-pytest tests/test_assumption_register.py -x -q
-```
-Expected: all pass.
-
-**Step 5: Commit**
-
-```bash
-git add src/stage_02_valuation/assumption_register.py tests/test_assumption_register.py
-git commit -m "feat: add RANGE_RULES table and flag_for_value() logic"
-```
-
----
-
-## Task 3: `build_assumption_register()` — assembles a register from valuation inputs
-
-**Files:**
-- Modify: `src/stage_02_valuation/assumption_register.py`
-- Modify: `tests/test_assumption_register.py`
-
-**Step 1: Write failing test**
-
-Add to `tests/test_assumption_register.py`:
-
-```python
-from src.stage_02_valuation.assumption_register import build_assumption_register
-from src.stage_02_valuation.valuation_types import ForecastDrivers
-
-def _minimal_drivers() -> ForecastDrivers:
-    return ForecastDrivers(
-        revenue_base=10_000.0,
-        revenue_growth_near=0.08,
-        revenue_growth_mid=0.05,
-        revenue_growth_terminal=0.025,
-        ebit_margin_start=0.18,
-        ebit_margin_target=0.22,
-        tax_rate_start=0.21,
-        tax_rate_target=0.21,
-        capex_pct_start=0.05,
-        capex_pct_target=0.04,
-        da_pct_start=0.04,
-        da_pct_target=0.04,
-        dso_start=45.0,
-        dso_target=45.0,
-        dio_start=30.0,
-        dio_target=30.0,
-        dpo_start=35.0,
-        dpo_target=35.0,
-        wacc=0.09,
-        exit_multiple=12.0,
-        exit_metric="ev_ebitda",
-        net_debt=500.0,
-        shares_outstanding=100.0,
-    )
-
-def test_build_assumption_register_returns_register():
-    drivers = _minimal_drivers()
-    lineage = {"revenue_growth_near": "yfinance_cagr_3yr", "ebit_margin_start": "ciq"}
-    reg = build_assumption_register("AAPL", drivers, lineage)
-    assert reg.ticker == "AAPL"
-    assert len(reg.entries) > 0
-
-def test_build_assumption_register_in_range_drivers_have_no_flag():
-    drivers = _minimal_drivers()
-    reg = build_assumption_register("AAPL", drivers, {})
-    flagged = [e for e in reg.entries if e.flag_level != FlagLevel.none]
-    assert len(flagged) == 0
-
-def test_build_assumption_register_out_of_range_driver_is_flagged():
-    drivers = _minimal_drivers()
-    drivers = ForecastDrivers(**{**drivers.__dict__, "ebit_margin_start": 0.80})
-    reg = build_assumption_register("AAPL", drivers, {})
-    flagged = [e for e in reg.entries if e.assumption_name == "ebit_margin_start"]
-    assert flagged[0].flag_level != FlagLevel.none
-
-def test_build_assumption_register_lineage_flows_to_source():
-    drivers = _minimal_drivers()
-    lineage = {"ebit_margin_start": "ciq"}
-    reg = build_assumption_register("AAPL", drivers, lineage)
-    entry = next(e for e in reg.entries if e.assumption_name == "ebit_margin_start")
-    assert entry.source == "ciq"
-```
-
-**Step 2: Run tests to verify they fail**
-
-```
-pytest tests/test_assumption_register.py::test_build_assumption_register_returns_register -x -q
-```
-Expected: ImportError on `build_assumption_register`.
-
-**Step 3: Implement `build_assumption_register()`**
-
-Add to `src/stage_02_valuation/assumption_register.py`:
-
-```python
-from src.stage_02_valuation.valuation_types import ForecastDrivers
-
-
-def build_assumption_register(
-    ticker: str,
-    drivers: ForecastDrivers,
-    source_lineage: dict[str, str],
-) -> AssumptionRegister:
-    """Build a fully-flagged assumption register from a completed ForecastDrivers."""
-    driver_values: dict[str, float] = {
-        "revenue_growth_near":          drivers.revenue_growth_near,
-        "revenue_growth_mid":           drivers.revenue_growth_mid,
-        "ebit_margin_start":            drivers.ebit_margin_start,
-        "ebit_margin_target":           drivers.ebit_margin_target,
-        "tax_rate_start":               drivers.tax_rate_start,
-        "tax_rate_target":              drivers.tax_rate_target,
-        "capex_pct_start":              drivers.capex_pct_start,
-        "capex_pct_target":             drivers.capex_pct_target,
-        "da_pct_start":                 drivers.da_pct_start,
-        "da_pct_target":                drivers.da_pct_target,
-        "dso_start":                    drivers.dso_start,
-        "dio_start":                    drivers.dio_start,
-        "dpo_start":                    drivers.dpo_start,
-        "wacc":                         drivers.wacc,
-        "exit_multiple":                drivers.exit_multiple,
-        "ronic_terminal":               drivers.ronic_terminal,
-        "terminal_blend_gordon_weight": drivers.terminal_blend_gordon_weight,
-    }
-
-    entries: list[AssumptionRegisterEntry] = []
-    for name, value in driver_values.items():
-        if name not in RANGE_RULES:
-            continue
-        low, high, rule_id = RANGE_RULES[name]
-        flag = flag_for_value(value, low, high)
-        owner = AssumptionOwner.deterministic
-        if source_lineage.get(name) == "pm_override":
-            owner = AssumptionOwner.pm_override
-        entries.append(AssumptionRegisterEntry(
-            assumption_name=name,
-            proposed_value=value,
-            accepted_low=low,
-            accepted_high=high,
-            range_rule_id=rule_id,
-            source=source_lineage.get(name, "derived"),
-            flag_level=flag,
-            owner=owner,
-        ))
-
-    return AssumptionRegister(ticker=ticker, entries=entries)
-```
-
-**Step 4: Run tests**
-
-```
-pytest tests/test_assumption_register.py -x -q
-```
-Expected: all pass.
-
-**Step 5: Commit**
-
-```bash
-git add src/stage_02_valuation/assumption_register.py tests/test_assumption_register.py
-git commit -m "feat: implement build_assumption_register() from ForecastDrivers + lineage"
-```
-
----
-
-## Task 4: Wire into `batch_runner.py`
-
-**Files:**
-- Modify: `src/stage_02_valuation/batch_runner.py` (around `value_single_ticker`)
-- Modify: `tests/test_batch_runner_professional.py`
-
-The batch runner already calls `build_valuation_inputs()` and has access to `drivers` and `source_lineage`. Wire `build_assumption_register()` after that call and attach the result to the output row as `assumption_register_json`.
-
-**Step 1: Write failing test**
-
-Find the test that exercises `value_single_ticker` in `tests/test_batch_runner_professional.py`. Add:
-
-```python
-def test_value_single_ticker_result_has_assumption_register(monkeypatch):
-    """assumption_register_json is present and has entries."""
-    import json
-    from tests.test_batch_runner_professional import _make_minimal_mkt  # reuse existing helper
-
-    # Use existing monkeypatch fixture from nearby test if available,
-    # or replicate the minimal mock pattern already in the file.
-    # The key assertion is on the result dict key.
-    result = _run_minimal_ticker(monkeypatch)  # helper defined in next step
-    assert "assumption_register_json" in result
-    reg = json.loads(result["assumption_register_json"])
-    assert "entries" in reg
-    assert len(reg["entries"]) > 0
-```
-
-Check the existing test file first to understand existing helper patterns before writing `_run_minimal_ticker`. Match the existing mock style exactly.
-
-**Step 2: Run test to verify it fails**
-
-```
-pytest tests/test_batch_runner_professional.py::test_value_single_ticker_result_has_assumption_register -x -q
-```
-Expected: either KeyError or the helper doesn't exist yet.
-
-**Step 3: Wire `build_assumption_register()` into `value_single_ticker()`**
-
-In `src/stage_02_valuation/batch_runner.py`, find where `valuation_inputs` is built:
-
-```python
-# existing pattern (approximately):
-valuation_inputs = build_valuation_inputs(ticker, ...)
-if valuation_inputs is None:
-    ...
-drivers = valuation_inputs.drivers
-```
-
-After that block, add:
-
-```python
-from src.stage_02_valuation.assumption_register import build_assumption_register
-import json as _json
-
-assumption_register = build_assumption_register(
-    ticker,
-    drivers,
-    valuation_inputs.source_lineage,
-)
-```
-
-Then in the result dict assembly, add:
-
-```python
-"assumption_register_json": _json.dumps(assumption_register.to_dict()),
-```
-
-**Step 4: Run tests**
-
-```
-pytest tests/test_batch_runner_professional.py -x -q
-```
-Expected: all pass including the new test.
-
-**Step 5: Commit**
-
-```bash
-git add src/stage_02_valuation/batch_runner.py tests/test_batch_runner_professional.py
-git commit -m "feat: wire assumption_register into batch_runner result row"
-```
-
----
-
-## Task 5: Wire into `json_exporter.py`
-
-**Files:**
-- Modify: `src/stage_02_valuation/json_exporter.py`
-- Modify: `tests/test_json_exporter.py`
-
-The JSON exporter builds the nested ticker payload. The assumption register should appear as a top-level `assumption_register` section — same pattern as `scenarios`, `wacc`, etc.
-
-**Step 1: Write failing test**
-
-In `tests/test_json_exporter.py`, add `assumption_register_json` to `MINIMAL_RESULT` (the test fixture dict) and assert the exported section exists:
-
-```python
-# Add to MINIMAL_RESULT dict (already defined at top of test file):
-# "assumption_register_json": json.dumps({"ticker": "IBM", "entries": [], "max_flag_level": "none", ...})
-
-def test_json_contains_assumption_register_section(tmp_dir):
-    import json as _json
-    result_with_reg = dict(MINIMAL_RESULT)
-    result_with_reg["assumption_register_json"] = _json.dumps({
-        "ticker": "IBM",
-        "max_flag_level": "none",
-        "has_critical": False,
-        "flag_counts": {"none": 1, "watch": 0, "review_required": 0, "critical": 0},
-        "entries": [{"assumption_name": "wacc", "proposed_value": 0.09,
-                     "accepted_low": 0.05, "accepted_high": 0.18,
-                     "range_rule_id": "wacc_default", "source": "derived",
-                     "flag_level": "none", "owner": "deterministic",
-                     "out_of_range": False, "notes": ""}],
-    })
-    dated = export_ticker_json(result_with_reg, output_dir=tmp_dir, date_str="2026-01-01")
-    content = _json.loads(dated.read_text())
-    assert "assumption_register" in content
-    assert content["assumption_register"]["max_flag_level"] == "none"
-```
-
-**Step 2: Run test to verify it fails**
-
-```
-pytest tests/test_json_exporter.py::test_json_contains_assumption_register_section -x -q
-```
-Expected: AssertionError — section missing.
-
-**Step 3: Add `assumption_register` to `build_nested_structure()`**
-
-In `src/stage_02_valuation/json_exporter.py`, find `build_nested_structure()`. Add:
-
-```python
-# near the other _safe_json_loads() calls:
-"assumption_register": _safe_json_loads(result.get("assumption_register_json")) or {},
-```
-
-**Step 4: Run tests**
-
-```
-pytest tests/test_json_exporter.py -x -q
-```
-Expected: all pass.
-
-**Step 5: Commit**
-
-```bash
-git add src/stage_02_valuation/json_exporter.py tests/test_json_exporter.py
-git commit -m "feat: add assumption_register section to json_exporter nested output"
-```
-
----
-
-## Task 6: Surface flags in `override_workbench.py`
-
-**Files:**
-- Modify: `src/stage_04_pipeline/override_workbench.py`
-- Test: no new test file — extend existing workbench test if one exists, or assert on the dict key in a minimal inline test
-
-The override workbench returns a dict from `build_override_workbench(ticker)`. Add an `assumption_register` key to that dict so the dashboard can surface flag counts and per-assumption detail without a separate API call.
-
-**Step 1: Write failing test**
-
-```python
-# tests/test_override_workbench_assumption_register.py
-import pytest
-from unittest.mock import patch, MagicMock
-from src.stage_04_pipeline.override_workbench import build_override_workbench
-
-def _fake_valuation_inputs(apply_overrides=True):
-    from src.stage_02_valuation.valuation_types import ForecastDrivers
-    from src.stage_02_valuation.input_assembler import ValuationInputsWithLineage
-    drivers = ForecastDrivers(
-        revenue_base=10_000.0, revenue_growth_near=0.08, revenue_growth_mid=0.05,
-        revenue_growth_terminal=0.025, ebit_margin_start=0.18, ebit_margin_target=0.22,
-        tax_rate_start=0.21, tax_rate_target=0.21, capex_pct_start=0.05,
-        capex_pct_target=0.04, da_pct_start=0.04, da_pct_target=0.04,
-        dso_start=45.0, dso_target=45.0, dio_start=30.0, dio_target=30.0,
-        dpo_start=35.0, dpo_target=35.0, wacc=0.09, exit_multiple=12.0,
-        exit_metric="ev_ebitda", net_debt=500.0, shares_outstanding=100.0,
-    )
-    return ValuationInputsWithLineage(
-        ticker="FAKE", company_name="Fake Co", sector="Technology", industry="Software",
-        current_price=100.0, as_of_date=None, model_applicability_status="dcf_applicable",
-        drivers=drivers, source_lineage={}, ciq_lineage={}, wacc_inputs={},
-    )
-
-def test_build_override_workbench_includes_assumption_register(monkeypatch):
-    monkeypatch.setattr(
-        "src.stage_04_pipeline.override_workbench.build_valuation_inputs",
-        _fake_valuation_inputs,
-    )
-    result = build_override_workbench("FAKE")
-    assert "assumption_register" in result
-    assert "entries" in result["assumption_register"]
-    assert "max_flag_level" in result["assumption_register"]
-```
-
-**Step 2: Run test to verify it fails**
-
-```
-pytest tests/test_override_workbench_assumption_register.py -x -q
-```
-Expected: KeyError — key not present.
-
-**Step 3: Add assumption register to `build_override_workbench()`**
-
-In `src/stage_04_pipeline/override_workbench.py`, find `build_override_workbench()`. After building `effective_inputs`, add:
-
-```python
-from src.stage_02_valuation.assumption_register import build_assumption_register
-
-assumption_register = build_assumption_register(
-    ticker,
-    effective_inputs.drivers,
-    effective_inputs.source_lineage,
-)
-```
-
-Then add to the returned dict:
-
-```python
-"assumption_register": assumption_register.to_dict(),
-```
-
-**Step 4: Run tests**
-
-```
-pytest tests/test_override_workbench_assumption_register.py -x -q
-```
-Expected: pass.
-
-**Step 5: Commit**
-
-```bash
-git add src/stage_04_pipeline/override_workbench.py tests/test_override_workbench_assumption_register.py
-git commit -m "feat: surface assumption_register in override_workbench payload"
-```
-
----
-
-## Task 7: Full suite check and doc update
-
-**Step 1: Run the full test bundle for this branch**
-
-```
-pytest tests/test_assumption_register.py tests/test_json_exporter.py tests/test_batch_runner_professional.py tests/test_override_workbench_assumption_register.py -q
-```
-Expected: all pass, no errors.
-
-**Step 2: Update the action plan doc**
-
-In `docs/design-docs/valuation-methodology-critical-review-and-action-plan.md`, mark P0 #1 ("Define the assumption register as an executable contract") and P0 #2 ("Make accepted ranges deterministic by default") as implemented. Add a one-line note: "Implemented in `src/stage_02_valuation/assumption_register.py` — range rules are in `RANGE_RULES`, flags computed by `flag_for_value()`."
-
-**Step 3: Commit docs**
-
-```bash
-git add docs/design-docs/valuation-methodology-critical-review-and-action-plan.md
-git commit -m "docs: mark P0 #1 and P0 #2 implemented in action plan"
-```
-
----
-
-## Notes for the implementer
-
-- `ForecastDrivers` is a `dataclass(slots=True)` — you cannot do `drivers.__dict__`. Use `dataclasses.asdict(drivers)` or access fields directly.
-- The test file `tests/test_batch_runner_professional.py` already has a detailed mock pattern for `value_single_ticker`. Read it before writing Task 4's test — match the existing helper style exactly rather than inventing a new one.
-- `_safe_json_loads()` is already defined in `json_exporter.py` — use it as-is for Task 5.
-- Keep `assumption_register.py` import-safe: the `from src.stage_02_valuation.valuation_types import ForecastDrivers` import inside `build_assumption_register()` avoids any circular import risk.
+## V2 Backlog
+
+- Connect `driver_assessments.py` and judgment-stage agents as advisory register inputs.
+- Feed register flags back to advisory agents so they can retry or revise proposed assumptions.
+- Add `source_quality_state` or equivalent source-confidence classification separate from numeric range checks.
+- Add automatic sensitivity-driven valuation-impact scoring for flagged assumptions.
+- Add raw/pre-clamp value diagnostics if review of clamped assumptions becomes important.
+- Replace fixed bps thresholds with scale-aware and valuation-impact-aware materiality.
+- Compute accepted ranges from company history, peer/industry context, and Damodaran data.
+- Populate sector, industry, and global assumption policy entries.
+- Add qualitative/enum/text assumptions only after numeric register behavior is stable.
+- Add scenario assumption packs for bear/base/bull and context-aware scenario cases.
+- Integrate Damodaran ERP, country-risk, synthetic-rating, and sector data into range/source policy.
+
+## Assumptions
+
+- Existing deterministic valuation should continue to run even with critical register flags.
+- Existing `valuation_overrides.yaml` and override audit paths remain authoritative for official PM changes.
+- V1 should avoid broad React redesign; show register data through existing valuation assumptions surfaces first.
+- The initial implementation should not scrape Damodaran data or build the config editor.

--- a/docs/plans/2026-05-16-grill-fixes-mvp.md
+++ b/docs/plans/2026-05-16-grill-fixes-mvp.md
@@ -1,0 +1,615 @@
+# Grill Fixes — MVP Cut
+
+> **For Claude:** REQUIRED SUB-SKILL: Use executing-plans to implement this plan task-by-task.
+
+**Goal:** Close the actionable P0 items from the valuation methodology critical review that make the pipeline trustworthy for PM testing. Three focused commits — no forecast scoping (deferred), no duplicate plumbing.
+
+**Architecture:** Additive changes to `src/contracts/`, `src/stage_02_valuation/`, and `src/stage_02_valuation/wacc.py`. No new LLM calls, no broad refactors. Each task adds one or two files and tests, then a GitHub issue is opened for any deferred V2 work.
+
+**Tech Stack:** Python 3.13, Pydantic V2, pytest, existing `src/contracts/assumption_register.py`, `src/stage_02_valuation/assumption_register.py`, `src/stage_02_valuation/wacc.py`, `src/stage_02_valuation/batch_runner.py`.
+
+---
+
+## Pre-Flight — Read These Before Touching Anything
+
+```
+src/contracts/assumption_register.py          — DEFAULT_ACCEPTED_RANGES, FlagLevel, AssumptionRegister
+src/stage_02_valuation/assumption_register.py — CRITICAL_DIAGNOSTICS, REVIEW_DIAGNOSTICS,
+                                                 _apply_diagnostic_rollup (uses object.__setattr__)
+src/stage_02_valuation/wacc.py:478-500        — compute_wacc_methodology_set_for_ticker()
+src/stage_02_valuation/batch_runner.py:598-612 — register_diagnostics assembly
+src/stage_02_valuation/professional_dcf.py:501 — terminal_ronic_guardrail_flag already computed
+src/stage_03_judgment/forensic_scores.py:381  — forensic_flag values: "red", "amber", "green"
+src/contracts/peer_universe.py                — does NOT exist yet
+tests/test_assumption_register.py             — prior art for test style
+tests/conftest.py                             — tmp_path override (use if test needs temp dirs)
+```
+
+**Key facts confirmed before writing this plan:**
+
+- `terminal_ronic_guardrail_flag` is already computed in `professional_dcf.py:501` as
+  `bool(d.ronic_terminal <= terminal_growth + 0.005)` (uses raw `d.ronic_terminal`). It flows
+  through as `health_terminal_ronic_guardrail_flag` in `register_diagnostics`. It is NOT in
+  `CRITICAL_DIAGNOSTICS`. Adding it there is 1 line.
+- `forensic_flag` lives at `row.get("forensic_flag")` (top-level flat key in the batch row
+  from `qoe_signals`). Values: `"red"` (manipulator zone), `"amber"` (caution), `"green"`.
+- `revenue_growth_terminal` accepted high is `0.05` — must be `0.04`.
+- `AssumptionRegister.notes` is a `dict`, not a string.
+- `_apply_diagnostic_rollup` mutates the register with `object.__setattr__` — safe for dicts.
+- `PeerCandidate.composite_score` weight breakdown: biz=0.35, metric=0.35, sector=0.15, size=0.15.
+  `sector_score = 1.0` only when both `sector_match AND industry_match`. With only
+  `sector_match=True`, `sector_score = 0.6` → composite ≈ 0.72 → `peripheral`, not `core`.
+
+---
+
+## Task A: `peer_universe.py` Contract
+
+The grill session named this as the second contract after assumption_register. It is foundational for the comps workbench (TD-03 replacement path).
+
+**Files:**
+- Create: `src/contracts/peer_universe.py`
+- Create: `tests/test_peer_universe_contract.py`
+
+### Step 1: Write the failing tests
+
+```python
+# tests/test_peer_universe_contract.py
+import pytest
+from src.contracts.peer_universe import PeerCandidate, PeerUniverse, InclusionState
+
+
+def test_peer_candidate_core_when_both_sector_and_industry_match():
+    """Both sector + industry match → sector_score=1.0 → should reach core threshold."""
+    c = PeerCandidate(
+        target_ticker="AAPL",
+        peer_ticker="MSFT",
+        sources=["ciq"],
+        sector_match=True,
+        industry_match=True,
+        business_description_similarity=0.80,
+        metric_similarity=0.72,
+        size_similarity=0.65,
+        growth_similarity=0.60,
+        margin_similarity=0.70,
+        capital_intensity_similarity=0.55,
+    )
+    # composite = 0.80*0.35 + 0.72*0.35 + 1.0*0.15 + 0.65*0.15 = 0.28+0.252+0.15+0.0975 = 0.7795
+    assert c.composite_score == pytest.approx(0.7795, abs=0.01)
+    assert c.inclusion_state == InclusionState.core
+
+
+def test_peer_candidate_peripheral_when_sector_only():
+    """sector_match only (no industry) → sector_score=0.6 → peripheral range."""
+    c = PeerCandidate(
+        target_ticker="AAPL",
+        peer_ticker="GOOG",
+        sources=["ciq"],
+        sector_match=True,
+        industry_match=False,
+        business_description_similarity=0.70,
+        metric_similarity=0.65,
+        size_similarity=0.60,
+        growth_similarity=0.55,
+        margin_similarity=0.60,
+        capital_intensity_similarity=0.50,
+    )
+    # composite = 0.70*0.35 + 0.65*0.35 + 0.6*0.15 + 0.60*0.15 = 0.245+0.2275+0.09+0.09 = 0.6525
+    assert c.composite_score == pytest.approx(0.6525, abs=0.01)
+    assert c.inclusion_state == InclusionState.peripheral
+
+
+def test_peer_candidate_excluded_below_threshold():
+    c = PeerCandidate(
+        target_ticker="X", peer_ticker="Y", sources=["test"],
+        sector_match=False, industry_match=False,
+        business_description_similarity=0.30, metric_similarity=0.30,
+        size_similarity=0.30, growth_similarity=0.30,
+        margin_similarity=0.30, capital_intensity_similarity=0.30,
+    )
+    assert c.inclusion_state == InclusionState.excluded
+
+
+def test_peer_universe_core_peers_list():
+    c = PeerCandidate(
+        target_ticker="AAPL", peer_ticker="MSFT", sources=["ciq"],
+        sector_match=True, industry_match=True,
+        business_description_similarity=0.90, metric_similarity=0.85,
+        size_similarity=0.80, growth_similarity=0.75,
+        margin_similarity=0.80, capital_intensity_similarity=0.70,
+    )
+    u = PeerUniverse(target_ticker="AAPL", candidates=[c])
+    assert "MSFT" in u.core_peers
+    assert u.peripheral_peers == []
+
+
+def test_peer_universe_round_trip():
+    c = PeerCandidate(
+        target_ticker="AAPL", peer_ticker="MSFT", sources=["ciq"],
+        sector_match=True, industry_match=True,
+        business_description_similarity=0.9, metric_similarity=0.8,
+        size_similarity=0.7, growth_similarity=0.7,
+        margin_similarity=0.8, capital_intensity_similarity=0.6,
+    )
+    u = PeerUniverse(target_ticker="AAPL", candidates=[c])
+    dumped = u.model_dump(mode="json")
+    restored = PeerUniverse.model_validate(dumped)
+    assert restored.target_ticker == "AAPL"
+    assert restored.core_peers == ["MSFT"]
+
+
+def test_pm_override_promotes_excluded_peer():
+    c = PeerCandidate(
+        target_ticker="X", peer_ticker="Y", sources=["pm"],
+        sector_match=False, industry_match=False,
+        business_description_similarity=0.20, metric_similarity=0.20,
+        size_similarity=0.20, growth_similarity=0.20,
+        margin_similarity=0.20, capital_intensity_similarity=0.20,
+        pm_override_state="included",
+        pm_override_reason="Closest proxy available",
+    )
+    assert c.inclusion_state == InclusionState.excluded    # raw score still low
+    assert c.effective_inclusion == InclusionState.core    # PM override wins
+
+
+def test_tickers_uppercased():
+    c = PeerCandidate(
+        target_ticker="aapl", peer_ticker="msft", sources=[],
+        sector_match=True, industry_match=True,
+        business_description_similarity=0.8, metric_similarity=0.8,
+        size_similarity=0.8, growth_similarity=0.8,
+        margin_similarity=0.8, capital_intensity_similarity=0.8,
+    )
+    assert c.target_ticker == "AAPL"
+    assert c.peer_ticker == "MSFT"
+```
+
+Run: `pytest tests/test_peer_universe_contract.py -v`
+Expected: ImportError (module not yet created)
+
+### Step 2: Implement `src/contracts/peer_universe.py`
+
+```python
+from __future__ import annotations
+
+from enum import Enum
+from typing import Literal
+
+from pydantic import BaseModel, Field, computed_field, model_validator
+
+PEER_UNIVERSE_CONTRACT_VERSION = "1.0"
+
+W_BIZ = 0.35       # business description similarity
+W_METRIC = 0.35    # metric similarity
+W_SECTOR = 0.15    # sector/industry match
+W_SIZE = 0.15      # size similarity
+
+CORE_THRESHOLD = 0.75
+PERIPHERAL_THRESHOLD = 0.55
+
+
+class InclusionState(str, Enum):
+    core = "core"
+    peripheral = "peripheral"
+    excluded = "excluded"
+
+
+class ContractModel(BaseModel):
+    model_config = {"extra": "ignore", "populate_by_name": True}
+
+
+class PeerCandidate(ContractModel):
+    contract_version: str = PEER_UNIVERSE_CONTRACT_VERSION
+    target_ticker: str
+    peer_ticker: str
+    sources: list[str] = Field(default_factory=list)
+
+    sector_match: bool = False
+    industry_match: bool = False
+
+    business_description_similarity: float = Field(ge=0.0, le=1.0, default=0.0)
+    metric_similarity: float = Field(ge=0.0, le=1.0, default=0.0)
+    size_similarity: float = Field(ge=0.0, le=1.0, default=0.0)
+    growth_similarity: float = Field(ge=0.0, le=1.0, default=0.0)
+    margin_similarity: float = Field(ge=0.0, le=1.0, default=0.0)
+    capital_intensity_similarity: float = Field(ge=0.0, le=1.0, default=0.0)
+
+    pm_override_state: Literal["included", "excluded", None] = None
+    pm_override_reason: str | None = None
+
+    @computed_field  # type: ignore[misc]
+    @property
+    def composite_score(self) -> float:
+        sector_score = (
+            1.0 if (self.sector_match and self.industry_match)
+            else 0.6 if self.sector_match
+            else 0.0
+        )
+        return (
+            W_BIZ * self.business_description_similarity
+            + W_METRIC * self.metric_similarity
+            + W_SECTOR * sector_score
+            + W_SIZE * self.size_similarity
+        )
+
+    @computed_field  # type: ignore[misc]
+    @property
+    def inclusion_state(self) -> InclusionState:
+        if self.composite_score >= CORE_THRESHOLD:
+            return InclusionState.core
+        if self.composite_score >= PERIPHERAL_THRESHOLD:
+            return InclusionState.peripheral
+        return InclusionState.excluded
+
+    @computed_field  # type: ignore[misc]
+    @property
+    def effective_inclusion(self) -> InclusionState:
+        if self.pm_override_state == "included":
+            return InclusionState.core
+        if self.pm_override_state == "excluded":
+            return InclusionState.excluded
+        return self.inclusion_state
+
+    @model_validator(mode="after")
+    def _uppercase_tickers(self) -> "PeerCandidate":
+        object.__setattr__(self, "target_ticker", self.target_ticker.upper().strip())
+        object.__setattr__(self, "peer_ticker", self.peer_ticker.upper().strip())
+        return self
+
+
+class PeerUniverse(ContractModel):
+    contract_version: str = PEER_UNIVERSE_CONTRACT_VERSION
+    target_ticker: str
+    candidates: list[PeerCandidate] = Field(default_factory=list)
+    build_source: str = "system"
+    notes: str | None = None
+
+    @computed_field  # type: ignore[misc]
+    @property
+    def core_peers(self) -> list[str]:
+        return [c.peer_ticker for c in self.candidates
+                if c.effective_inclusion == InclusionState.core]
+
+    @computed_field  # type: ignore[misc]
+    @property
+    def peripheral_peers(self) -> list[str]:
+        return [c.peer_ticker for c in self.candidates
+                if c.effective_inclusion == InclusionState.peripheral]
+
+    @model_validator(mode="after")
+    def _uppercase_ticker(self) -> "PeerUniverse":
+        object.__setattr__(self, "target_ticker", self.target_ticker.upper().strip())
+        return self
+```
+
+### Step 3: Run tests
+
+`pytest tests/test_peer_universe_contract.py -v`
+Expected: 7 passed
+
+### Step 4: Commit
+
+```
+git add src/contracts/peer_universe.py tests/test_peer_universe_contract.py
+git commit -m "feat: add PeerUniverse and PeerCandidate contracts with composite scoring (#53-followup)"
+```
+
+**Open GitHub issue now:**
+```bash
+gh issue create \
+  --title "V2: wire PeerUniverse into comps workbench and batch runner (replaces TD-03)" \
+  --label "area:valuation,priority:p2,type:feature" \
+  --body "PeerCandidate/PeerUniverse contracts in src/contracts/peer_universe.py. Next: wire composite scoring into batch runner peer selection, replace get_peer_multiples() returning self with real ranked candidates. Relates to TD-03 in tech-debt-tracker."
+```
+
+---
+
+## Task B: Extend Diagnostic Rollup (All Four Diagnostics, One Commit)
+
+Four small wires into the same diagnostic machinery. Do them together to avoid merge conflicts on `CRITICAL_DIAGNOSTICS`, `REVIEW_DIAGNOSTICS`, and `_apply_diagnostic_rollup`.
+
+**Files:**
+- Modify: `src/stage_02_valuation/assumption_register.py` (CRITICAL_DIAGNOSTICS, REVIEW_DIAGNOSTICS, _apply_diagnostic_rollup)
+- Modify: `src/stage_02_valuation/wacc.py` (add method-spread computation)
+- Modify: `src/stage_02_valuation/input_assembler.py` (pass wacc_method_spread_high)
+- Modify: `src/stage_02_valuation/batch_runner.py` (add forensic_flag_severe + regime_label to register_diagnostics)
+- Modify: `tests/test_assumption_register.py` (four new tests)
+
+### Step 1: Write four failing tests
+
+```python
+# Add to tests/test_assumption_register.py
+
+# ── helpers reused across tests ────────────────────────────────────────────
+
+def _base_inputs(**driver_overrides):
+    """Minimal FakeInputs for assumption_register tests."""
+    base_drivers = dict(
+        revenue_growth_near=0.08, revenue_growth_mid=0.05,
+        ebit_margin_start=0.20, ebit_margin_target=0.22,
+        tax_rate_start=0.21, tax_rate_target=0.21,
+        capex_pct_start=0.05, capex_pct_target=0.05,
+        da_pct_start=0.04, da_pct_target=0.04,
+        dso_start=45.0, dso_target=45.0,
+        dio_start=0.0, dio_target=0.0,
+        dpo_start=30.0, dpo_target=30.0,
+        wacc=0.09, exit_multiple=15.0,
+        ronic_terminal=0.12, revenue_growth_terminal=0.025,
+    )
+    base_drivers.update(driver_overrides)
+
+    class FakeInputs:
+        wacc_inputs = {
+            "wacc": 0.09, "risk_free_rate": 0.045, "equity_risk_premium": 0.05,
+            "beta_relevered": 1.0, "size_premium": 0.01, "cost_of_debt": 0.05,
+            "equity_weight": 0.8, "debt_weight": 0.2, "cost_of_equity": 0.11,
+        }
+        drivers = type("D", (), base_drivers)()
+        source_lineage = {}
+        model_applicability_status = "dcf_applicable"
+
+    return FakeInputs()
+
+
+def test_ronic_guardrail_flag_critical():
+    """health_terminal_ronic_guardrail_flag=True must produce critical trust state."""
+    from src.stage_02_valuation.assumption_register import build_assumption_register
+    from src.contracts.assumption_register import ModelTrustState
+
+    reg = build_assumption_register(
+        "TEST", _base_inputs(),
+        diagnostics={"health_terminal_ronic_guardrail_flag": True},
+    )
+    assert reg.model_trust_state in (
+        ModelTrustState.critical_review_required.value,
+        ModelTrustState.critical_review_required,
+    )
+
+
+def test_wacc_method_spread_flags_review():
+    """wacc_method_spread_high=True must produce at least review_required trust state."""
+    from src.stage_02_valuation.assumption_register import build_assumption_register
+    from src.contracts.assumption_register import ModelTrustState, FlagLevel
+
+    reg = build_assumption_register(
+        "TEST", _base_inputs(),
+        diagnostics={"wacc_method_spread_high": True},
+    )
+    assert reg.model_trust_state not in (
+        ModelTrustState.clean.value, ModelTrustState.watch.value,
+        ModelTrustState.clean, ModelTrustState.watch,
+    )
+
+
+def test_forensic_red_flag_critical():
+    """forensic_flag_severe=True must degrade trust state to critical or degraded."""
+    from src.stage_02_valuation.assumption_register import build_assumption_register
+    from src.contracts.assumption_register import ModelTrustState
+
+    reg = build_assumption_register(
+        "TEST", _base_inputs(),
+        diagnostics={"forensic_flag_severe": True},
+    )
+    assert reg.model_trust_state in (
+        ModelTrustState.critical_review_required.value,
+        ModelTrustState.critical_review_required,
+    )
+
+
+def test_regime_label_in_register_notes():
+    """regime_weights_applied=True must store regime label in register.notes dict."""
+    from src.stage_02_valuation.assumption_register import build_assumption_register
+
+    reg = build_assumption_register(
+        "TEST", _base_inputs(),
+        diagnostics={"regime_label": "Risk-Off", "regime_weights_applied": True},
+    )
+    assert "regime_label" in reg.notes
+    assert reg.notes["regime_label"] == "Risk-Off"
+```
+
+Run: `pytest tests/test_assumption_register.py::test_ronic_guardrail_flag_critical tests/test_assumption_register.py::test_wacc_method_spread_flags_review tests/test_assumption_register.py::test_forensic_red_flag_critical tests/test_assumption_register.py::test_regime_label_in_register_notes -v`
+Expected: all FAIL (diagnostics not wired yet)
+
+### Step 2: Wire B1 — add ronic guardrail to CRITICAL_DIAGNOSTICS
+
+In `src/stage_02_valuation/assumption_register.py`, find:
+
+```python
+CRITICAL_DIAGNOSTICS = {
+    "health_terminal_denominator_guardrail_flag",
+    "terminal_denominator_guardrail_flag",
+    "health_terminal_growth_guardrail_flag",
+    "terminal_growth_guardrail_flag",
+}
+```
+
+Add `"health_terminal_ronic_guardrail_flag"` to this set.
+
+### Step 3: Wire B2 — WACC method-spread
+
+**In `src/stage_02_valuation/wacc.py`**, at the end of `compute_wacc_methodology_set_for_ticker()`, after the three method results are collected into `results`:
+
+```python
+WACC_DISAGREEMENT_THRESHOLD = 0.015  # 150bps
+
+method_waccs = {
+    k: getattr(v, "wacc", None)
+    for k, v in results.items()
+    if getattr(v, "wacc", None) is not None
+}
+if len(method_waccs) >= 2:
+    spread = max(method_waccs.values()) - min(method_waccs.values())
+    results["_meta"] = {
+        "wacc_method_spread": round(spread, 4),
+        "wacc_method_spread_high": spread >= WACC_DISAGREEMENT_THRESHOLD,
+        "method_waccs": method_waccs,
+    }
+return results
+```
+
+**In `src/stage_02_valuation/input_assembler.py`**, after computing `wacc_method_results`, add:
+
+```python
+wacc_meta = wacc_method_results.get("_meta") or {}
+wacc_method_spread_high = bool(wacc_meta.get("wacc_method_spread_high", False))
+```
+
+Then store it — add a field `wacc_method_spread_high: bool = False` to `ValuationInputsWithLineage` (check what dataclass/model that is) or pass it through the existing `drivers` struct. If neither is easy, just store in a module-level thread-local or return it alongside inputs. **Check what `ValuationInputsWithLineage` is before modifying it** (`grep -n "class ValuationInputsWithLineage" src/stage_02_valuation/input_assembler.py`).
+
+**In `src/stage_02_valuation/batch_runner.py`**, add to `register_diagnostics`:
+
+```python
+"wacc_method_spread_high": getattr(inputs, "wacc_method_spread_high", False),
+```
+
+**In `src/stage_02_valuation/assumption_register.py`**, add `"wacc_method_spread_high"` to `REVIEW_DIAGNOSTICS`.
+
+### Step 4: Wire B3 — forensic_flag_severe
+
+**In `src/stage_02_valuation/batch_runner.py`**, in the `register_diagnostics` dict assembly:
+
+```python
+"forensic_flag_severe": row.get("forensic_flag") == "red",
+```
+
+**In `src/stage_02_valuation/assumption_register.py`**, add `"forensic_flag_severe"` to `CRITICAL_DIAGNOSTICS`.
+
+### Step 5: Wire B4 — regime label in notes
+
+**In `src/stage_02_valuation/batch_runner.py`**, in the `register_diagnostics` dict assembly:
+
+```python
+"regime_label": regime.label if regime_weights else None,
+"regime_weights_applied": regime_weights is not None,
+```
+
+(Check the exact variable name for the regime object — look at lines 492–508 of `batch_runner.py`.)
+
+**In `src/stage_02_valuation/assumption_register.py`**, in `_apply_diagnostic_rollup`, at the end of the function (after the trust state logic), add:
+
+```python
+if diagnostics.get("regime_weights_applied"):
+    current_notes = dict(register.notes or {})
+    current_notes["regime_label"] = diagnostics.get("regime_label") or "unknown"
+    current_notes["regime_weights_applied"] = True
+    object.__setattr__(register, "notes", current_notes)
+```
+
+This is safe — `notes` is a plain `dict` field with no validators.
+
+### Step 6: Run tests
+
+`pytest tests/test_assumption_register.py -v`
+Expected: all pass (existing 9 + 4 new = 13 total)
+
+### Step 7: Commit
+
+```
+git add src/stage_02_valuation/assumption_register.py src/stage_02_valuation/wacc.py \
+        src/stage_02_valuation/input_assembler.py src/stage_02_valuation/batch_runner.py \
+        tests/test_assumption_register.py
+git commit -m "feat: extend diagnostic rollup — ronic guardrail critical, WACC spread review, forensic red critical, regime label in notes"
+```
+
+**Open GitHub issues now:**
+```bash
+gh issue create \
+  --title "V2: expose WACC method comparison table in React WACC workbench" \
+  --label "area:frontend,priority:p2,type:feature" \
+  --body "WACC methodology set (peer_bottom_up, industry_proxy, self_hamada) already computed. Method spread diagnostic (wacc_method_spread_high) now wires into assumption register. Surface as a comparison table in React WACC tab."
+
+gh issue create \
+  --title "V2: forensic score detail panel in PM review (M-Score breakdown, Z-Score distress)" \
+  --label "area:frontend,priority:p2,type:feature" \
+  --body "Beneish M-Score and Altman Z-Score are deterministic and canon-blessed. Severe forensic_flag=red now degrades model trust state. Surface M-Score component breakdown and Z-Score distress zone in React PM review panel."
+
+gh issue create \
+  --title "V2: forecast scoping scorecard — tier badge in React valuation card" \
+  --label "area:frontend,priority:p2,type:feature" \
+  --body "Deferred from grill-fixes MVP. Implement assess_forecast_complexity() scorecard that returns full/moderate/light/blocked tier from observable inputs (data coverage, history depth, profitability, revenue volatility). Surface as badge in React valuation card and dossier."
+
+gh issue create \
+  --title "V2: deterministic accepted ranges from trailing 5Y p25-p75 per metric" \
+  --label "area:valuation,priority:p2,type:feature" \
+  --body "Current DEFAULT_ACCEPTED_RANGES are static. Grill session specified ranges should derive from trailing 5-year p25-p75 per metric cross-checked against peers. Requires historical data pipeline investment."
+```
+
+---
+
+## Task C: Terminal Growth Cap
+
+**Files:**
+- Modify: `src/contracts/assumption_register.py` (change `revenue_growth_terminal` high from 0.05 → 0.04)
+- Modify: `tests/test_assumption_register.py` (pin the rule with a test)
+
+### Step 1: Write the failing test
+
+```python
+# Add to tests/test_assumption_register.py
+
+def test_terminal_growth_accepted_high_capped_at_four_percent():
+    from src.contracts.assumption_register import DEFAULT_ACCEPTED_RANGES
+    r = DEFAULT_ACCEPTED_RANGES.get("revenue_growth_terminal")
+    assert r is not None, "revenue_growth_terminal must have a range rule"
+    assert r["high"] <= 0.04, (
+        f"Terminal growth cap must be ≤ 4% (long-run nominal), got {r['high']}"
+    )
+```
+
+Run: `pytest tests/test_assumption_register.py::test_terminal_growth_accepted_high_capped_at_four_percent -v`
+Expected: FAIL (current value is 0.05)
+
+### Step 2: Fix the range
+
+In `src/contracts/assumption_register.py`, find:
+
+```python
+"revenue_growth_terminal": {"low": 0.00, "high": 0.05, "description": "Terminal growth should stay within mature nominal growth guardrails."},
+```
+
+Change `"high": 0.05` → `"high": 0.04` and update description:
+
+```python
+"revenue_growth_terminal": {"low": 0.00, "high": 0.04, "description": "Terminal growth capped at long-run nominal GDP growth (4%)."},
+```
+
+### Step 3: Run tests
+
+`pytest tests/test_assumption_register.py -v`
+Expected: all pass
+
+### Step 4: Commit
+
+```
+git add src/contracts/assumption_register.py tests/test_assumption_register.py
+git commit -m "fix: cap terminal growth accepted range high at 4% per long-run nominal GDP rule"
+```
+
+---
+
+## Final Verification
+
+```bash
+python -m pytest tests/test_assumption_register.py tests/test_peer_universe_contract.py \
+  tests/test_assumption_policy.py tests/test_api_contracts.py \
+  tests/test_batch_runner_professional.py tests/test_json_exporter.py \
+  tests/test_override_workbench.py tests/test_recommendations.py \
+  tests/test_ticker_dossier_contract_runtime.py tests/test_valuation_input_assembler.py -q
+```
+
+Expected: 130+ passed, 0 errors.
+
+Then: `npm --prefix frontend run build` — must be clean.
+
+Open PR targeting `main`, title: `feat: grill fixes MVP — peer universe contract, diagnostic rollup extension, terminal growth cap`
+
+---
+
+## GitHub Issues Opened During This Plan
+
+All opened inline above. Summary:
+1. V2: wire PeerUniverse into comps workbench (TD-03 replacement)
+2. V2: WACC method comparison table in React
+3. V2: forensic score detail panel in React PM review
+4. V2: forecast scoping scorecard + React badge
+5. V2: deterministic accepted ranges from trailing 5Y p25-p75

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -17,6 +17,8 @@ import type {
   ValuationCompsPayload,
   ValuationDcfPayload,
   ValuationSummaryPayload,
+  ValuationPolicyPayload,
+  ValuationPolicyPreviewPayload,
   WatchlistPayload,
   WatchlistExportRequest,
   WatchlistExportSourceMode,
@@ -91,6 +93,28 @@ export function getValuationComps(ticker: string): Promise<ValuationCompsPayload
 
 export function getValuationAssumptions(ticker: string): Promise<AssumptionsPayload> {
   return requestJSON<AssumptionsPayload>(`/tickers/${encodeURIComponent(ticker)}/valuation/assumptions`);
+}
+
+export function getValuationPolicy(): Promise<ValuationPolicyPayload> {
+  return requestJSON<ValuationPolicyPayload>("/valuation/policy");
+}
+
+export function previewValuationPolicy(payload: unknown): Promise<ValuationPolicyPreviewPayload> {
+  return requestJSON<ValuationPolicyPreviewPayload>("/valuation/policy/preview", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
+export function saveValuationPolicy(payload: unknown): Promise<ValuationPolicyPayload> {
+  return requestJSON<ValuationPolicyPayload>("/valuation/policy", {
+    method: "PUT",
+    body: JSON.stringify(payload),
+  });
+}
+
+export function parseDamodaranPolicyDrafts(): Promise<Record<string, unknown>> {
+  return requestJSON<Record<string, unknown>>("/valuation/policy/damodaran/parse", { method: "POST" });
 }
 
 export function previewValuationAssumptions(ticker: string, payload: unknown): Promise<AssumptionsPreviewPayload> {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -181,6 +181,7 @@ export interface AssumptionsPayload {
     initial_mode?: string | null;
   }>;
   audit_rows?: Array<Record<string, unknown>>;
+  pending_changes?: Array<Record<string, unknown>>;
 }
 
 export interface AssumptionsPreviewPayload {
@@ -219,6 +220,26 @@ export interface WaccPreviewPayload {
   current_expected_iv?: number | null;
   proposed_expected_iv?: number | null;
   method_result?: Record<string, unknown>;
+}
+
+export interface ValuationPolicyPayload {
+  contract_version?: string;
+  policy_id?: number | null;
+  created_at?: string | null;
+  actor?: string | null;
+  global_defaults: {
+    risk_free_rate?: number | null;
+    equity_risk_premium?: number | null;
+  };
+  sector_defaults?: Record<string, Record<string, number>>;
+  source_ref?: string | null;
+  notes?: string | null;
+}
+
+export interface ValuationPolicyPreviewPayload {
+  current_policy?: ValuationPolicyPayload;
+  proposed_policy?: ValuationPolicyPayload;
+  changed_fields?: Record<string, Record<string, unknown>>;
 }
 
 export interface DcfFcffPoint {

--- a/frontend/src/pages/ValuationPage.tsx
+++ b/frontend/src/pages/ValuationPage.tsx
@@ -13,11 +13,13 @@ import {
   getValuationAssumptions,
   getValuationComps,
   getValuationDcf,
+  getValuationPolicy,
   getValuationSummary,
   getWacc,
   previewRecommendations,
   previewValuationAssumptions,
   previewWacc,
+  saveValuationPolicy,
 } from "@/lib/api";
 import { downloadCompletedExport, getCompletedExportId } from "@/lib/exportJobs";
 import { formatCurrency, formatDateLabel, formatPercent, formatText } from "@/lib/format";
@@ -25,6 +27,7 @@ import type {
   RecommendationsPayload,
   RecommendationsPreviewPayload,
   TickerWorkspace,
+  ValuationPolicyPayload,
   WaccPreviewPayload,
 } from "@/lib/types";
 
@@ -887,6 +890,13 @@ function MultiplesPanel({ comps }: { comps: Record<string, unknown> | null | und
 
 function AssumptionsPanel({
   assumptions,
+  policy,
+  policyRf,
+  setPolicyRf,
+  policyErp,
+  setPolicyErp,
+  onSavePolicy,
+  policySavePending,
   selections,
   setSelections,
   customValues,
@@ -899,6 +909,13 @@ function AssumptionsPanel({
   runStatus,
 }: {
   assumptions: Record<string, unknown> | null | undefined;
+  policy: ValuationPolicyPayload | null | undefined;
+  policyRf: number;
+  setPolicyRf: Dispatch<SetStateAction<number>>;
+  policyErp: number;
+  setPolicyErp: Dispatch<SetStateAction<number>>;
+  onSavePolicy: () => void;
+  policySavePending: boolean;
   selections: Record<string, string>;
   setSelections: Dispatch<SetStateAction<Record<string, string>>>;
   customValues: Record<string, number>;
@@ -912,6 +929,7 @@ function AssumptionsPanel({
 }) {
   const fields = asRows(assumptions?.fields);
   const auditRows = asRows(assumptions?.audit_rows);
+  const pendingChanges = asRows(assumptions?.pending_changes);
   return (
     <section className="page-stack">
       <section className="grid-cards">
@@ -919,6 +937,64 @@ function AssumptionsPanel({
         <article className="panel"><h2>Current Price</h2><p>{formatCurrency(asNumber(assumptions?.current_price))}</p></article>
         <article className="panel"><h2>Tracked Fields</h2><p>{fields.length}</p></article>
         <article className="panel"><h2>Current Expected IV</h2><p>{formatCurrency(asNumber(assumptions?.current_expected_iv))}</p></article>
+      </section>
+      <section className="panel">
+        <div className="panel-toolbar">
+          <div>
+            <h2>Policy Defaults</h2>
+            <p className="table-note">{formatText(asText(policy?.source_ref ?? "DB valuation policy"))}</p>
+          </div>
+          <button type="button" className="primary-button" onClick={onSavePolicy} disabled={policySavePending}>
+            {policySavePending ? "Saving..." : "Save Policy"}
+          </button>
+        </div>
+        <div className="valuation-form-grid">
+          <div>
+            <label className="form-label" htmlFor="policy-risk-free-rate">Risk-free rate</label>
+            <input
+              id="policy-risk-free-rate"
+              className="form-input"
+              type="number"
+              step="0.001"
+              value={policyRf}
+              onChange={(event) => setPolicyRf(Number(event.target.value))}
+            />
+          </div>
+          <div>
+            <label className="form-label" htmlFor="policy-equity-risk-premium">Equity risk premium</label>
+            <input
+              id="policy-equity-risk-premium"
+              className="form-input"
+              type="number"
+              step="0.001"
+              value={policyErp}
+              onChange={(event) => setPolicyErp(Number(event.target.value))}
+            />
+          </div>
+        </div>
+      </section>
+      <section className="panel">
+        <h2>Pending Changes</h2>
+        {renderValueTable(
+          pendingChanges.map((change) => ({
+            id: change.change_id,
+            field: change.assumption_name,
+            current: change.current_value,
+            proposed: change.proposed_value,
+            source: change.source_ref,
+            confidence: change.confidence,
+            status: change.status,
+          })),
+          [
+            { key: "id", label: "ID", kind: "number" },
+            { key: "field", label: "Field", kind: "text" },
+            { key: "current", label: "Current", kind: "number" },
+            { key: "proposed", label: "Proposed", kind: "number" },
+            { key: "source", label: "Source", kind: "text" },
+            { key: "confidence", label: "Confidence", kind: "text" },
+            { key: "status", label: "Status", kind: "text" },
+          ],
+        )}
       </section>
       <section className="stacked-cards">
         {fields.map((field) => {
@@ -1300,6 +1376,8 @@ export function ValuationPage() {
   const selected = (params.get("view") ?? "Summary") as ValuationTab;
   const [assumptionSelections, setAssumptionSelections] = useState<Record<string, string>>({});
   const [assumptionCustomValues, setAssumptionCustomValues] = useState<Record<string, number>>({});
+  const [policyRf, setPolicyRf] = useState(0.045);
+  const [policyErp, setPolicyErp] = useState(0.05);
   const [waccMode, setWaccMode] = useState("single_method");
   const [waccSelectedMethod, setWaccSelectedMethod] = useState("peer_bottom_up");
   const [waccWeights, setWaccWeights] = useState<Record<string, number>>({});
@@ -1329,6 +1407,11 @@ export function ValuationPage() {
     queryKey: ["ticker-valuation-assumptions", ticker],
     queryFn: () => getValuationAssumptions(ticker),
     enabled: Boolean(ticker) && selected === "Assumptions",
+  });
+  const policyQuery = useQuery({
+    queryKey: ["valuation-policy"],
+    queryFn: () => getValuationPolicy(),
+    enabled: selected === "Assumptions",
   });
   const waccQuery = useQuery({
     queryKey: ["ticker-valuation-wacc", ticker],
@@ -1366,6 +1449,14 @@ export function ValuationPage() {
     setWaccWeights((waccQuery.data.current_selection?.weights as Record<string, number> | undefined) ?? {});
   }, [waccQuery.data]);
 
+  useEffect(() => {
+    if (!policyQuery.data?.global_defaults) {
+      return;
+    }
+    setPolicyRf(Number(policyQuery.data.global_defaults.risk_free_rate ?? 0.045));
+    setPolicyErp(Number(policyQuery.data.global_defaults.equity_risk_premium ?? 0.05));
+  }, [policyQuery.data]);
+
   const assumptionsPreviewMutation = useMutation({
     mutationFn: () =>
       previewValuationAssumptions(ticker, {
@@ -1390,6 +1481,19 @@ export function ValuationPage() {
         ),
       }),
     onSuccess: (payload) => setAssumptionsRunId(payload.run_id),
+  });
+  const policySaveMutation = useMutation({
+    mutationFn: () =>
+      saveValuationPolicy({
+        global_defaults: {
+          risk_free_rate: policyRf,
+          equity_risk_premium: policyErp,
+        },
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["valuation-policy"] }).catch(() => undefined);
+      queryClient.invalidateQueries({ queryKey: ["ticker-valuation-assumptions", ticker] }).catch(() => undefined);
+    },
   });
 
   const waccPreviewMutation = useMutation({
@@ -1497,6 +1601,13 @@ export function ValuationPage() {
         return assumptionsQuery.isPending && !assumptionsQuery.data ? renderLoadingPanel("Assumptions") : (
           <AssumptionsPanel
             assumptions={assumptionsQuery.data as unknown as Record<string, unknown>}
+            policy={policyQuery.data}
+            policyRf={policyRf}
+            setPolicyRf={setPolicyRf}
+            policyErp={policyErp}
+            setPolicyErp={setPolicyErp}
+            onSavePolicy={() => policySaveMutation.mutate()}
+            policySavePending={policySaveMutation.isPending}
             selections={assumptionSelections}
             setSelections={setAssumptionSelections}
             customValues={assumptionCustomValues}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ markers = [
 ]
 tmp_path_retention_policy = "failed"
 tmp_path_retention_count = 3
-addopts = "--basetemp=.tmp-tests"
 
 [tool.ruff]
 target-version = "py311"

--- a/src/contracts/assumption_policy.py
+++ b/src/contracts/assumption_policy.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+ASSUMPTION_POLICY_CONTRACT_VERSION = "1.0.0"
+
+
+class ContractModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class PendingAssumptionStatus(str, Enum):
+    pending = "pending"
+    approved = "approved"
+    rejected = "rejected"
+    superseded = "superseded"
+
+
+class PendingAssumptionSourceType(str, Enum):
+    agent = "agent"
+    pm = "pm"
+    policy = "policy"
+    damodaran = "damodaran"
+    migration = "migration"
+
+
+class ValuationPolicyGlobalDefaults(ContractModel):
+    risk_free_rate: float = Field(default=0.045, ge=0.0, le=0.20)
+    equity_risk_premium: float = Field(default=0.05, ge=0.0, le=0.20)
+
+
+class SectorDefaultPolicy(ContractModel):
+    sector: str
+    defaults: dict[str, float] = Field(default_factory=dict)
+
+    @field_validator("sector")
+    @classmethod
+    def _clean_sector(cls, value: str) -> str:
+        return str(value).strip() or "_default"
+
+
+class ValuationPolicy(ContractModel):
+    contract_version: str = ASSUMPTION_POLICY_CONTRACT_VERSION
+    policy_id: int | None = None
+    created_at: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    actor: str = "system"
+    global_defaults: ValuationPolicyGlobalDefaults = Field(default_factory=ValuationPolicyGlobalDefaults)
+    sector_defaults: dict[str, dict[str, float]] = Field(default_factory=dict)
+    source_ref: str | None = None
+    notes: str | None = None
+
+
+class ValuationPolicyPreview(ContractModel):
+    current_policy: ValuationPolicy
+    proposed_policy: ValuationPolicy
+    changed_fields: dict[str, dict[str, Any]] = Field(default_factory=dict)
+
+
+class DamodaranPolicyDraft(ContractModel):
+    draft_id: int | None = None
+    created_at: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    source_file: str
+    source_kind: str
+    row_key: str
+    field: str
+    value: float
+    unit: str | None = None
+    source_date: str | None = None
+    status: Literal["draft", "accepted", "rejected"] = "draft"
+    raw: dict[str, Any] = Field(default_factory=dict)
+
+
+class PendingAssumptionChange(ContractModel):
+    change_id: int | None = None
+    created_at: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    updated_at: str | None = None
+    ticker: str
+    assumption_name: str
+    current_value: float | None = None
+    proposed_value: float
+    source_type: PendingAssumptionSourceType = PendingAssumptionSourceType.agent
+    source_ref: str
+    confidence: str | None = None
+    rationale: str | None = None
+    citation: str | None = None
+    status: PendingAssumptionStatus = PendingAssumptionStatus.pending
+    approval_ref: str | None = None
+    applied_at: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("ticker")
+    @classmethod
+    def _uppercase_ticker(cls, value: str) -> str:
+        return str(value).upper().strip()
+
+    @field_validator("assumption_name", "source_ref")
+    @classmethod
+    def _strip_required(cls, value: str) -> str:
+        cleaned = str(value).strip()
+        if not cleaned:
+            raise ValueError("field is required")
+        return cleaned
+
+
+class PendingAssumptionStackPreview(ContractModel):
+    ticker: str
+    selected_change_ids: list[int] = Field(default_factory=list)
+    current_iv: dict[str, float | None] = Field(default_factory=dict)
+    proposed_iv: dict[str, float | None] = Field(default_factory=dict)
+    delta_pct: dict[str, float | None] = Field(default_factory=dict)
+    resolved_values: dict[str, dict[str, Any]] = Field(default_factory=dict)
+    conflicts: list[dict[str, Any]] = Field(default_factory=list)
+
+    @field_validator("ticker")
+    @classmethod
+    def _uppercase_preview_ticker(cls, value: str) -> str:
+        return str(value).upper().strip()

--- a/src/contracts/assumption_register.py
+++ b/src/contracts/assumption_register.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+ASSUMPTION_REGISTER_CONTRACT_VERSION = "1.0.0"
+
+ALLOWED_STAGES = frozenset({"input_assembly", "wacc", "dcf", "terminal_value"})
+ALLOWED_SCOPES = frozenset({
+    "growth",
+    "margin",
+    "tax",
+    "working_capital",
+    "reinvestment",
+    "wacc",
+    "terminal_value",
+    "capital_structure",
+})
+ALLOWED_FORECAST_LINES = frozenset({
+    "revenue",
+    "ebit",
+    "nopat",
+    "fcff",
+    "terminal_value",
+    "enterprise_value",
+    "equity_value",
+})
+
+
+class ContractModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class AssumptionEntityType(str, Enum):
+    ticker = "ticker"
+    sector = "sector"
+    industry = "industry"
+    global_ = "global"
+
+
+class AssumptionOwner(str, Enum):
+    deterministic = "deterministic"
+    pm_override = "pm_override"
+    system_flag = "system_flag"
+
+
+class AssumptionApprovalState(str, Enum):
+    none = "none"
+    review_required = "review_required"
+    pm_approved = "pm_approved"
+    rejected = "rejected"
+    stale_approval = "stale_approval"
+
+
+class FlagLevel(str, Enum):
+    none = "none"
+    watch = "watch"
+    review_required = "review_required"
+    critical = "critical"
+
+
+class AssumptionValueType(str, Enum):
+    numeric = "numeric"
+
+
+class ModelTrustState(str, Enum):
+    clean = "clean"
+    watch = "watch"
+    review_required = "review_required"
+    critical_review_required = "critical_review_required"
+
+
+FLAG_SEVERITY: dict[FlagLevel, int] = {
+    FlagLevel.none: 0,
+    FlagLevel.watch: 1,
+    FlagLevel.review_required: 2,
+    FlagLevel.critical: 3,
+}
+
+
+class AssumptionRegisterEntry(ContractModel):
+    entity_type: AssumptionEntityType
+    entity_id: str
+    ticker: str
+    assumption_name: str
+    scope: str
+    stage: str
+    value_type: AssumptionValueType = AssumptionValueType.numeric
+    current_value: float
+    accepted_low: float | None = None
+    accepted_high: float | None = None
+    range_rule_id: str
+    range_rule_description: str
+    source_lineage: dict[str, Any] = Field(default_factory=dict)
+    affected_forecast_lines: list[str] = Field(default_factory=list)
+    flag_level: FlagLevel = FlagLevel.none
+    owner: AssumptionOwner = AssumptionOwner.deterministic
+    approval_state: AssumptionApprovalState = AssumptionApprovalState.none
+    approval_ref: str | None = None
+    out_of_range: bool = False
+    valuation_impact: dict[str, Any] | None = None
+    evidence_refs: list[str] = Field(default_factory=list)
+    advisory_refs: list[str] = Field(default_factory=list)
+    notes: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("ticker", "entity_id")
+    @classmethod
+    def _uppercase_identifier(cls, value: str) -> str:
+        return str(value).upper().strip()
+
+    @field_validator("stage")
+    @classmethod
+    def _validate_stage(cls, value: str) -> str:
+        if value not in ALLOWED_STAGES:
+            raise ValueError(f"stage must be one of {sorted(ALLOWED_STAGES)}")
+        return value
+
+    @field_validator("scope")
+    @classmethod
+    def _validate_scope(cls, value: str) -> str:
+        if value not in ALLOWED_SCOPES:
+            raise ValueError(f"scope must be one of {sorted(ALLOWED_SCOPES)}")
+        return value
+
+    @field_validator("affected_forecast_lines")
+    @classmethod
+    def _validate_forecast_lines(cls, values: list[str]) -> list[str]:
+        unknown = sorted(set(values) - ALLOWED_FORECAST_LINES)
+        if unknown:
+            raise ValueError(f"unknown affected_forecast_lines: {unknown}")
+        return values
+
+    @model_validator(mode="after")
+    def _derive_out_of_range(self) -> "AssumptionRegisterEntry":
+        if self.accepted_low is not None and self.current_value < self.accepted_low:
+            object.__setattr__(self, "out_of_range", True)
+        elif self.accepted_high is not None and self.current_value > self.accepted_high:
+            object.__setattr__(self, "out_of_range", True)
+        return self
+
+
+class AssumptionRegister(ContractModel):
+    contract_version: str = ASSUMPTION_REGISTER_CONTRACT_VERSION
+    ticker: str
+    generated_at: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    entries: list[AssumptionRegisterEntry] = Field(default_factory=list)
+    flag_counts: dict[str, int] = Field(default_factory=dict)
+    max_flag_level: FlagLevel = FlagLevel.none
+    has_critical: bool = False
+    model_trust_state: ModelTrustState = ModelTrustState.clean
+    summary: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("ticker")
+    @classmethod
+    def _uppercase_ticker(cls, value: str) -> str:
+        return str(value).upper().strip()
+
+    @model_validator(mode="after")
+    def _derive_rollups(self) -> "AssumptionRegister":
+        counts = {level.value: 0 for level in FlagLevel}
+        max_level = FlagLevel.none
+        for entry in self.entries:
+            counts[entry.flag_level.value] += 1
+            if FLAG_SEVERITY[entry.flag_level] > FLAG_SEVERITY[max_level]:
+                max_level = entry.flag_level
+        object.__setattr__(self, "flag_counts", counts)
+        object.__setattr__(self, "max_flag_level", max_level)
+        object.__setattr__(self, "has_critical", max_level == FlagLevel.critical)
+        if max_level == FlagLevel.critical:
+            object.__setattr__(self, "model_trust_state", ModelTrustState.critical_review_required)
+        elif max_level == FlagLevel.review_required:
+            object.__setattr__(self, "model_trust_state", ModelTrustState.review_required)
+        elif max_level == FlagLevel.watch:
+            object.__setattr__(self, "model_trust_state", ModelTrustState.watch)
+        else:
+            object.__setattr__(self, "model_trust_state", ModelTrustState.clean)
+        object.__setattr__(self, "summary", {
+            "model_trust_state": self.model_trust_state.value,
+            "flag_counts": self.flag_counts,
+            "max_flag_level": self.max_flag_level.value,
+            "has_critical": self.has_critical,
+        })
+        return self
+
+
+class AuditDiff(ContractModel):
+    event_ts: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    actor: str = "system"
+    actor_type: Literal["system", "pm", "agent"] = "system"
+    entity_type: AssumptionEntityType
+    entity_id: str
+    ticker: str
+    assumption_name: str
+    scope: str
+    event_type: str
+    changed_fields: dict[str, dict[str, Any]]
+    valuation_impact: dict[str, Any] | None = None
+    reason: str | None = None

--- a/src/contracts/assumption_register.py
+++ b/src/contracts/assumption_register.py
@@ -153,6 +153,7 @@ class AssumptionRegister(ContractModel):
     has_critical: bool = False
     model_trust_state: ModelTrustState = ModelTrustState.clean
     summary: dict[str, Any] = Field(default_factory=dict)
+    notes: dict[str, Any] = Field(default_factory=dict)
 
     @field_validator("ticker")
     @classmethod

--- a/src/contracts/peer_universe.py
+++ b/src/contracts/peer_universe.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Literal
+
+from pydantic import BaseModel, Field, computed_field, model_validator
+
+PEER_UNIVERSE_CONTRACT_VERSION = "1.0"
+
+W_BIZ = 0.35       # business description similarity
+W_METRIC = 0.35    # metric similarity
+W_SECTOR = 0.15    # sector/industry match
+W_SIZE = 0.15      # size similarity
+
+CORE_THRESHOLD = 0.75
+PERIPHERAL_THRESHOLD = 0.55
+
+
+class InclusionState(str, Enum):
+    core = "core"
+    peripheral = "peripheral"
+    excluded = "excluded"
+
+
+class ContractModel(BaseModel):
+    model_config = {"extra": "ignore", "populate_by_name": True}
+
+
+class PeerCandidate(ContractModel):
+    contract_version: str = PEER_UNIVERSE_CONTRACT_VERSION
+    target_ticker: str
+    peer_ticker: str
+    sources: list[str] = Field(default_factory=list)
+
+    sector_match: bool = False
+    industry_match: bool = False
+
+    business_description_similarity: float = Field(ge=0.0, le=1.0, default=0.0)
+    metric_similarity: float = Field(ge=0.0, le=1.0, default=0.0)
+    size_similarity: float = Field(ge=0.0, le=1.0, default=0.0)
+    growth_similarity: float = Field(ge=0.0, le=1.0, default=0.0)
+    margin_similarity: float = Field(ge=0.0, le=1.0, default=0.0)
+    capital_intensity_similarity: float = Field(ge=0.0, le=1.0, default=0.0)
+
+    pm_override_state: Literal["included", "excluded", None] = None
+    pm_override_reason: str | None = None
+
+    @computed_field  # type: ignore[misc]
+    @property
+    def composite_score(self) -> float:
+        sector_score = (
+            1.0 if (self.sector_match and self.industry_match)
+            else 0.6 if self.sector_match
+            else 0.0
+        )
+        return (
+            W_BIZ * self.business_description_similarity
+            + W_METRIC * self.metric_similarity
+            + W_SECTOR * sector_score
+            + W_SIZE * self.size_similarity
+        )
+
+    @computed_field  # type: ignore[misc]
+    @property
+    def inclusion_state(self) -> InclusionState:
+        if self.composite_score >= CORE_THRESHOLD:
+            return InclusionState.core
+        if self.composite_score >= PERIPHERAL_THRESHOLD:
+            return InclusionState.peripheral
+        return InclusionState.excluded
+
+    @computed_field  # type: ignore[misc]
+    @property
+    def effective_inclusion(self) -> InclusionState:
+        if self.pm_override_state == "included":
+            return InclusionState.core
+        if self.pm_override_state == "excluded":
+            return InclusionState.excluded
+        return self.inclusion_state
+
+    @model_validator(mode="after")
+    def _uppercase_tickers(self) -> "PeerCandidate":
+        object.__setattr__(self, "target_ticker", self.target_ticker.upper().strip())
+        object.__setattr__(self, "peer_ticker", self.peer_ticker.upper().strip())
+        return self
+
+
+class PeerUniverse(ContractModel):
+    contract_version: str = PEER_UNIVERSE_CONTRACT_VERSION
+    target_ticker: str
+    candidates: list[PeerCandidate] = Field(default_factory=list)
+    build_source: str = "system"
+    notes: str | None = None
+
+    @computed_field  # type: ignore[misc]
+    @property
+    def core_peers(self) -> list[str]:
+        return [c.peer_ticker for c in self.candidates
+                if c.effective_inclusion == InclusionState.core]
+
+    @computed_field  # type: ignore[misc]
+    @property
+    def peripheral_peers(self) -> list[str]:
+        return [c.peer_ticker for c in self.candidates
+                if c.effective_inclusion == InclusionState.peripheral]
+
+    @model_validator(mode="after")
+    def _uppercase_ticker(self) -> "PeerUniverse":
+        object.__setattr__(self, "target_ticker", self.target_ticker.upper().strip())
+        return self

--- a/src/stage_02_valuation/assumption_register.py
+++ b/src/stage_02_valuation/assumption_register.py
@@ -241,7 +241,7 @@ def _entry_payload(
 def _wacc_payloads(inputs: Any, drivers: dict[str, Any]) -> dict[str, Any]:
     raw = getattr(inputs, "wacc_inputs", None) or {}
     out = {
-        "wacc": raw.get("wacc", drivers.get("wacc")),
+        "wacc": drivers.get("wacc", raw.get("wacc")),
         "cost_of_equity": raw.get("cost_of_equity", drivers.get("cost_of_equity")),
         "risk_free_rate": raw.get("risk_free_rate", drivers.get("risk_free_rate")),
         "equity_risk_premium": raw.get("equity_risk_premium", drivers.get("equity_risk_premium")),

--- a/src/stage_02_valuation/assumption_register.py
+++ b/src/stage_02_valuation/assumption_register.py
@@ -60,7 +60,7 @@ RANGE_RULES: dict[str, dict[str, Any]] = {
     "revenue_base": {"low": 1.0, "high": None, "description": "Revenue base should be positive."},
     "revenue_growth_near": {"low": -0.20, "high": 0.30, "description": "Default PM review range for near-term revenue growth."},
     "revenue_growth_mid": {"low": -0.15, "high": 0.25, "description": "Default PM review range for mid-term revenue growth."},
-    "revenue_growth_terminal": {"low": 0.00, "high": 0.05, "description": "Terminal growth should stay within mature nominal growth guardrails."},
+    "revenue_growth_terminal": {"low": 0.00, "high": 0.04, "description": "Terminal growth capped at long-run nominal GDP growth (4%)."},
     "ebit_margin_start": {"low": -0.10, "high": 0.45, "description": "Default PM review range for starting EBIT margin."},
     "ebit_margin_target": {"low": -0.05, "high": 0.50, "description": "Default PM review range for target EBIT margin."},
     "tax_rate_start": {"low": 0.00, "high": 0.40, "description": "Default PM review range for effective tax rate."},

--- a/src/stage_02_valuation/assumption_register.py
+++ b/src/stage_02_valuation/assumption_register.py
@@ -120,8 +120,15 @@ CRITICAL_DIAGNOSTICS = {
     "terminal_denominator_guardrail_flag",
     "health_terminal_growth_guardrail_flag",
     "terminal_growth_guardrail_flag",
+    "health_terminal_ronic_guardrail_flag",  # RONIC ≤ terminal_growth — mathematically invalid
+    "forensic_flag_severe",                  # Beneish M-Score in manipulator zone (red)
 }
-REVIEW_DIAGNOSTICS = {"tv_high_flag", "health_tv_extreme_flag", "tv_extreme_flag"}
+REVIEW_DIAGNOSTICS = {
+    "tv_high_flag",
+    "health_tv_extreme_flag",
+    "tv_extreme_flag",
+    "wacc_method_spread_high",  # ≥150bps spread across WACC methods
+}
 
 
 def _now() -> str:
@@ -278,6 +285,11 @@ def _apply_diagnostic_rollup(register: AssumptionRegister, diagnostics: dict[str
         except (TypeError, ValueError):
             pass
     if max_flag == register.max_flag_level:
+        if diagnostics.get("regime_weights_applied"):
+            current_notes = dict(register.notes or {})
+            current_notes["regime_label"] = diagnostics.get("regime_label") or "unknown"
+            current_notes["regime_weights_applied"] = True
+            object.__setattr__(register, "notes", current_notes)
         return register
     object.__setattr__(register, "max_flag_level", max_flag)
     object.__setattr__(register, "has_critical", max_flag == FlagLevel.critical)
@@ -296,6 +308,13 @@ def _apply_diagnostic_rollup(register: AssumptionRegister, diagnostics: dict[str
         "has_critical": max_flag == FlagLevel.critical,
         "diagnostic_notes": diagnostic_notes,
     })
+
+    if diagnostics.get("regime_weights_applied"):
+        current_notes = dict(register.notes or {})
+        current_notes["regime_label"] = diagnostics.get("regime_label") or "unknown"
+        current_notes["regime_weights_applied"] = True
+        object.__setattr__(register, "notes", current_notes)
+
     return register
 
 

--- a/src/stage_02_valuation/assumption_register.py
+++ b/src/stage_02_valuation/assumption_register.py
@@ -1,0 +1,472 @@
+from __future__ import annotations
+
+import math
+from dataclasses import asdict, is_dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from src.contracts.assumption_register import (
+    AuditDiff,
+    AssumptionApprovalState,
+    AssumptionEntityType,
+    AssumptionOwner,
+    AssumptionRegister,
+    AssumptionRegisterEntry,
+    AssumptionValueType,
+    FLAG_SEVERITY,
+    FlagLevel,
+    ModelTrustState,
+)
+
+
+FIELD_METADATA: dict[str, dict[str, Any]] = {
+    "revenue_base": {"stage": "input_assembly", "scope": "growth", "lines": ["revenue", "fcff", "enterprise_value", "equity_value"], "class": "money"},
+    "revenue_growth_near": {"stage": "input_assembly", "scope": "growth", "lines": ["revenue", "fcff", "enterprise_value", "equity_value"], "class": "pct_driver"},
+    "revenue_growth_mid": {"stage": "input_assembly", "scope": "growth", "lines": ["revenue", "fcff", "enterprise_value", "equity_value"], "class": "pct_driver"},
+    "revenue_growth_terminal": {"stage": "terminal_value", "scope": "terminal_value", "lines": ["terminal_value", "enterprise_value", "equity_value"], "class": "pct_driver"},
+    "ebit_margin_start": {"stage": "input_assembly", "scope": "margin", "lines": ["ebit", "nopat", "fcff", "enterprise_value", "equity_value"], "class": "pct_driver"},
+    "ebit_margin_target": {"stage": "dcf", "scope": "margin", "lines": ["ebit", "nopat", "fcff", "enterprise_value", "equity_value"], "class": "pct_driver"},
+    "tax_rate_start": {"stage": "input_assembly", "scope": "tax", "lines": ["nopat", "fcff", "enterprise_value", "equity_value"], "class": "pct_driver"},
+    "tax_rate_target": {"stage": "dcf", "scope": "tax", "lines": ["nopat", "fcff", "enterprise_value", "equity_value"], "class": "pct_driver"},
+    "capex_pct_start": {"stage": "input_assembly", "scope": "reinvestment", "lines": ["fcff", "enterprise_value", "equity_value"], "class": "pct_driver"},
+    "capex_pct_target": {"stage": "dcf", "scope": "reinvestment", "lines": ["fcff", "enterprise_value", "equity_value"], "class": "pct_driver"},
+    "da_pct_start": {"stage": "input_assembly", "scope": "reinvestment", "lines": ["fcff", "enterprise_value", "equity_value"], "class": "pct_driver"},
+    "da_pct_target": {"stage": "dcf", "scope": "reinvestment", "lines": ["fcff", "enterprise_value", "equity_value"], "class": "pct_driver"},
+    "dso_start": {"stage": "input_assembly", "scope": "working_capital", "lines": ["fcff", "enterprise_value", "equity_value"], "class": "days"},
+    "dso_target": {"stage": "dcf", "scope": "working_capital", "lines": ["fcff", "enterprise_value", "equity_value"], "class": "days"},
+    "dio_start": {"stage": "input_assembly", "scope": "working_capital", "lines": ["fcff", "enterprise_value", "equity_value"], "class": "days"},
+    "dio_target": {"stage": "dcf", "scope": "working_capital", "lines": ["fcff", "enterprise_value", "equity_value"], "class": "days"},
+    "dpo_start": {"stage": "input_assembly", "scope": "working_capital", "lines": ["fcff", "enterprise_value", "equity_value"], "class": "days"},
+    "dpo_target": {"stage": "dcf", "scope": "working_capital", "lines": ["fcff", "enterprise_value", "equity_value"], "class": "days"},
+    "wacc": {"stage": "wacc", "scope": "wacc", "lines": ["enterprise_value", "equity_value"], "class": "wacc"},
+    "cost_of_equity": {"stage": "wacc", "scope": "wacc", "lines": ["equity_value"], "class": "wacc_component_rate"},
+    "risk_free_rate": {"stage": "wacc", "scope": "wacc", "lines": ["enterprise_value", "equity_value"], "class": "wacc_component_rate"},
+    "equity_risk_premium": {"stage": "wacc", "scope": "wacc", "lines": ["enterprise_value", "equity_value"], "class": "wacc_component_rate"},
+    "beta_relevered": {"stage": "wacc", "scope": "wacc", "lines": ["enterprise_value", "equity_value"], "class": "beta"},
+    "beta_unlevered_median": {"stage": "wacc", "scope": "wacc", "lines": ["enterprise_value", "equity_value"], "class": "beta"},
+    "size_premium": {"stage": "wacc", "scope": "wacc", "lines": ["enterprise_value", "equity_value"], "class": "wacc_component_rate"},
+    "cost_of_debt": {"stage": "wacc", "scope": "wacc", "lines": ["enterprise_value", "equity_value"], "class": "wacc_component_rate"},
+    "equity_weight": {"stage": "wacc", "scope": "capital_structure", "lines": ["enterprise_value", "equity_value"], "class": "capital_structure_weight"},
+    "debt_weight": {"stage": "wacc", "scope": "capital_structure", "lines": ["enterprise_value", "equity_value"], "class": "capital_structure_weight"},
+    "exit_multiple": {"stage": "terminal_value", "scope": "terminal_value", "lines": ["terminal_value", "enterprise_value", "equity_value"], "class": "multiple"},
+    "terminal_blend_gordon_weight": {"stage": "terminal_value", "scope": "terminal_value", "lines": ["terminal_value", "enterprise_value", "equity_value"], "class": "pct_driver"},
+    "terminal_blend_exit_weight": {"stage": "terminal_value", "scope": "terminal_value", "lines": ["terminal_value", "enterprise_value", "equity_value"], "class": "pct_driver"},
+    "ronic_terminal": {"stage": "terminal_value", "scope": "terminal_value", "lines": ["terminal_value", "enterprise_value", "equity_value"], "class": "pct_driver"},
+    "net_debt": {"stage": "input_assembly", "scope": "capital_structure", "lines": ["equity_value"], "class": "money"},
+    "shares_outstanding": {"stage": "input_assembly", "scope": "capital_structure", "lines": ["equity_value"], "class": "money"},
+}
+
+RANGE_RULES: dict[str, dict[str, Any]] = {
+    "revenue_base": {"low": 1.0, "high": None, "description": "Revenue base should be positive."},
+    "revenue_growth_near": {"low": -0.20, "high": 0.30, "description": "Default PM review range for near-term revenue growth."},
+    "revenue_growth_mid": {"low": -0.15, "high": 0.25, "description": "Default PM review range for mid-term revenue growth."},
+    "revenue_growth_terminal": {"low": 0.00, "high": 0.05, "description": "Terminal growth should stay within mature nominal growth guardrails."},
+    "ebit_margin_start": {"low": -0.10, "high": 0.45, "description": "Default PM review range for starting EBIT margin."},
+    "ebit_margin_target": {"low": -0.05, "high": 0.50, "description": "Default PM review range for target EBIT margin."},
+    "tax_rate_start": {"low": 0.00, "high": 0.40, "description": "Default PM review range for effective tax rate."},
+    "tax_rate_target": {"low": 0.00, "high": 0.40, "description": "Default PM review range for target tax rate."},
+    "capex_pct_start": {"low": 0.00, "high": 0.30, "description": "Default PM review range for capex as percent of revenue."},
+    "capex_pct_target": {"low": 0.00, "high": 0.30, "description": "Default PM review range for target capex as percent of revenue."},
+    "da_pct_start": {"low": 0.00, "high": 0.25, "description": "Default PM review range for D&A as percent of revenue."},
+    "da_pct_target": {"low": 0.00, "high": 0.25, "description": "Default PM review range for target D&A as percent of revenue."},
+    "dso_start": {"low": 0.0, "high": 180.0, "description": "Default PM review range for days sales outstanding."},
+    "dso_target": {"low": 0.0, "high": 180.0, "description": "Default PM review range for target DSO."},
+    "dio_start": {"low": 0.0, "high": 240.0, "description": "Default PM review range for days inventory outstanding."},
+    "dio_target": {"low": 0.0, "high": 240.0, "description": "Default PM review range for target DIO."},
+    "dpo_start": {"low": 0.0, "high": 240.0, "description": "Default PM review range for days payables outstanding."},
+    "dpo_target": {"low": 0.0, "high": 240.0, "description": "Default PM review range for target DPO."},
+    "wacc": {"low": 0.04, "high": 0.20, "description": "Default PM review range for WACC."},
+    "cost_of_equity": {"low": 0.04, "high": 0.30, "description": "Default PM review range for cost of equity."},
+    "risk_free_rate": {"low": 0.00, "high": 0.10, "description": "Default PM review range for risk-free rate."},
+    "equity_risk_premium": {"low": 0.02, "high": 0.10, "description": "Default PM review range for equity risk premium."},
+    "beta_relevered": {"low": 0.20, "high": 3.00, "description": "Default PM review range for relevered beta."},
+    "beta_unlevered_median": {"low": 0.20, "high": 3.00, "description": "Default PM review range for unlevered beta."},
+    "size_premium": {"low": 0.00, "high": 0.08, "description": "Default PM review range for size premium."},
+    "cost_of_debt": {"low": 0.00, "high": 0.20, "description": "Default PM review range for pre-tax cost of debt."},
+    "equity_weight": {"low": 0.20, "high": 1.00, "description": "Default PM review range for equity weight."},
+    "debt_weight": {"low": 0.00, "high": 0.80, "description": "Default PM review range for debt weight."},
+    "exit_multiple": {"low": 2.0, "high": 30.0, "description": "Default PM review range for terminal exit multiple."},
+    "terminal_blend_gordon_weight": {"low": 0.0, "high": 1.0, "description": "Gordon terminal blend weight should be a probability-like weight."},
+    "terminal_blend_exit_weight": {"low": 0.0, "high": 1.0, "description": "Exit terminal blend weight should be a probability-like weight."},
+    "ronic_terminal": {"low": 0.00, "high": 0.40, "description": "Default PM review range for terminal RONIC."},
+    "net_debt": {"low": None, "high": None, "description": "Capital-structure money field retained for review and audit."},
+    "shares_outstanding": {"low": 1.0, "high": None, "description": "Share count should be positive."},
+}
+
+MATERIALITY_RULES: dict[str, dict[str, Any]] = {
+    "wacc": {"threshold": 0.0025, "description": "25 bps WACC movement."},
+    "wacc_component_rate": {"threshold": 0.0025, "description": "25 bps WACC component movement."},
+    "beta": {"threshold": 0.10, "description": "0.10 beta point movement."},
+    "capital_structure_weight": {"threshold": 0.05, "description": "5 percentage point capital structure movement."},
+    "pct_driver": {"threshold": 0.005, "description": "50 bps percentage-driver movement."},
+    "multiple": {"threshold": 0.5, "description": "0.5x multiple movement."},
+    "days": {"threshold": 5.0, "description": "5 day working-capital movement."},
+    "money": {"threshold": 10_000_000.0, "revenue_ratio": 0.01, "description": "Greater of USD 10m or 1% of revenue base."},
+}
+
+AUDIT_ALWAYS_MATERIAL_FIELDS = {
+    "flag_level",
+    "source_lineage",
+    "owner",
+    "approval_state",
+    "approval_ref",
+    "range_rule_id",
+    "range_rule_description",
+}
+
+REVIEW_RELEVANT_FLAGS = {FlagLevel.watch, FlagLevel.review_required, FlagLevel.critical}
+CRITICAL_DIAGNOSTICS = {
+    "health_terminal_denominator_guardrail_flag",
+    "terminal_denominator_guardrail_flag",
+    "health_terminal_growth_guardrail_flag",
+    "terminal_growth_guardrail_flag",
+}
+REVIEW_DIAGNOSTICS = {"tv_high_flag", "health_tv_extreme_flag", "tv_extreme_flag"}
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _drivers_payload(inputs: Any) -> dict[str, Any]:
+    drivers = getattr(inputs, "drivers", None)
+    if drivers is None:
+        return {}
+    if is_dataclass(drivers):
+        return asdict(drivers)
+    if isinstance(drivers, dict):
+        return dict(drivers)
+    return {
+        key: getattr(drivers, key)
+        for key in FIELD_METADATA
+        if hasattr(drivers, key)
+    }
+
+
+def _normalise_source(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return dict(value)
+    if value is None:
+        return {"source": "unknown"}
+    return {"source": str(value)}
+
+
+def _is_pm_override(source_lineage: dict[str, Any]) -> bool:
+    text = " ".join(str(value) for value in source_lineage.values()).lower()
+    return "override" in text or "pm_approved" in text
+
+
+def _approval_ref(source_lineage: dict[str, Any]) -> str | None:
+    for key in ("approval_ref", "audit_ref", "override_audit_ref", "wacc_methodology_audit_ref"):
+        value = source_lineage.get(key)
+        if value:
+            return str(value)
+    return None
+
+
+def _rule_for(name: str) -> dict[str, Any]:
+    return RANGE_RULES.get(name, {"low": None, "high": None, "description": "No V1 range rule configured."})
+
+
+def _flag_for_value(name: str, value: float, low: float | None, high: float | None, diagnostics: dict[str, Any]) -> FlagLevel:
+    if math.isnan(value) or math.isinf(value):
+        return FlagLevel.critical
+    if name == "wacc" and value <= 0:
+        return FlagLevel.critical
+    if name == "revenue_growth_terminal":
+        wacc = diagnostics.get("wacc")
+        if isinstance(wacc, (int, float)) and value >= float(wacc):
+            return FlagLevel.critical
+        if value > 0.05:
+            return FlagLevel.critical
+    if low is not None and value < low:
+        return FlagLevel.review_required
+    if high is not None and value > high:
+        return FlagLevel.review_required
+    if low is not None and high is not None and high > low:
+        band = high - low
+        if value < low + band * 0.10 or value > high - band * 0.10:
+            return FlagLevel.watch
+    return FlagLevel.none
+
+
+def _entry_payload(
+    *,
+    ticker: str,
+    name: str,
+    value: Any,
+    source_lineage: dict[str, Any],
+    diagnostics: dict[str, Any],
+) -> dict[str, Any] | None:
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        return None
+    current_value = float(value)
+    metadata = FIELD_METADATA[name]
+    rule = _rule_for(name)
+    lineage = _normalise_source(source_lineage.get(name))
+    if name in {"risk_free_rate", "equity_risk_premium"} and name not in source_lineage:
+        lineage = _normalise_source(source_lineage.get("risk_free_rate"))
+    owner = AssumptionOwner.pm_override if _is_pm_override(lineage) else AssumptionOwner.deterministic
+    approval_ref = _approval_ref(lineage)
+    approval_state = AssumptionApprovalState.pm_approved if owner == AssumptionOwner.pm_override else AssumptionApprovalState.none
+    flag = _flag_for_value(name, current_value, rule.get("low"), rule.get("high"), diagnostics)
+    if flag in {FlagLevel.review_required, FlagLevel.critical} and approval_state == AssumptionApprovalState.none:
+        approval_state = AssumptionApprovalState.review_required
+    return {
+        "entity_type": AssumptionEntityType.ticker,
+        "entity_id": ticker,
+        "ticker": ticker,
+        "assumption_name": name,
+        "scope": metadata["scope"],
+        "stage": metadata["stage"],
+        "value_type": AssumptionValueType.numeric,
+        "current_value": current_value,
+        "accepted_low": rule.get("low"),
+        "accepted_high": rule.get("high"),
+        "range_rule_id": f"{name}_v1_static",
+        "range_rule_description": rule["description"],
+        "source_lineage": lineage,
+        "affected_forecast_lines": metadata["lines"],
+        "flag_level": flag,
+        "owner": owner,
+        "approval_state": approval_state,
+        "approval_ref": approval_ref,
+        "valuation_impact": None,
+        "evidence_refs": [],
+        "advisory_refs": [],
+        "notes": {},
+    }
+
+
+def _wacc_payloads(inputs: Any, drivers: dict[str, Any]) -> dict[str, Any]:
+    raw = getattr(inputs, "wacc_inputs", None) or {}
+    out = {
+        "wacc": raw.get("wacc", drivers.get("wacc")),
+        "cost_of_equity": raw.get("cost_of_equity", drivers.get("cost_of_equity")),
+        "risk_free_rate": raw.get("risk_free_rate", drivers.get("risk_free_rate")),
+        "equity_risk_premium": raw.get("equity_risk_premium", drivers.get("equity_risk_premium")),
+        "beta_relevered": raw.get("beta_relevered"),
+        "beta_unlevered_median": raw.get("beta_unlevered_median"),
+        "size_premium": raw.get("size_premium", drivers.get("size_premium")),
+        "cost_of_debt": raw.get("cost_of_debt", drivers.get("cost_of_debt")),
+        "equity_weight": raw.get("equity_weight"),
+        "debt_weight": raw.get("debt_weight", drivers.get("debt_weight")),
+    }
+    if out["equity_weight"] is None and isinstance(out["debt_weight"], (int, float)):
+        out["equity_weight"] = 1.0 - float(out["debt_weight"])
+    if out["debt_weight"] is None and isinstance(out["equity_weight"], (int, float)):
+        out["debt_weight"] = 1.0 - float(out["equity_weight"])
+    return out
+
+
+def _apply_diagnostic_rollup(register: AssumptionRegister, diagnostics: dict[str, Any]) -> AssumptionRegister:
+    max_flag = register.max_flag_level
+    diagnostic_notes: list[str] = []
+    if any(bool(diagnostics.get(key)) for key in CRITICAL_DIAGNOSTICS):
+        max_flag = FlagLevel.critical
+        diagnostic_notes.append("critical_terminal_guardrail")
+    elif any(bool(diagnostics.get(key)) for key in REVIEW_DIAGNOSTICS):
+        if FLAG_SEVERITY[max_flag] < FLAG_SEVERITY[FlagLevel.review_required]:
+            max_flag = FlagLevel.review_required
+        diagnostic_notes.append("terminal_concentration_or_extreme_tv")
+    elif diagnostics.get("tv_pct_of_ev") is not None:
+        try:
+            tv_pct = float(diagnostics["tv_pct_of_ev"])
+            if tv_pct > 0.70 and FLAG_SEVERITY[max_flag] < FLAG_SEVERITY[FlagLevel.watch]:
+                max_flag = FlagLevel.watch
+                diagnostic_notes.append("elevated_terminal_concentration")
+        except (TypeError, ValueError):
+            pass
+    if max_flag == register.max_flag_level:
+        return register
+    object.__setattr__(register, "max_flag_level", max_flag)
+    object.__setattr__(register, "has_critical", max_flag == FlagLevel.critical)
+    trust_state = (
+        ModelTrustState.critical_review_required.value
+        if max_flag == FlagLevel.critical
+        else ModelTrustState.review_required.value
+        if max_flag == FlagLevel.review_required
+        else ModelTrustState.watch.value
+    )
+    object.__setattr__(register, "model_trust_state", ModelTrustState(trust_state))
+    object.__setattr__(register, "summary", {
+        **register.summary,
+        "model_trust_state": trust_state,
+        "max_flag_level": max_flag.value,
+        "has_critical": max_flag == FlagLevel.critical,
+        "diagnostic_notes": diagnostic_notes,
+    })
+    return register
+
+
+def build_assumption_register(ticker: str, inputs: Any, diagnostics: dict[str, Any] | None = None) -> AssumptionRegister:
+    ticker = ticker.upper().strip()
+    diagnostics = dict(diagnostics or {})
+    drivers = _drivers_payload(inputs)
+    source_lineage = dict(getattr(inputs, "source_lineage", None) or {})
+    wacc_values = _wacc_payloads(inputs, drivers)
+    diagnostics.setdefault("wacc", wacc_values.get("wacc") or drivers.get("wacc"))
+
+    payloads: list[dict[str, Any]] = []
+    for name in FIELD_METADATA:
+        value = wacc_values.get(name) if name in wacc_values else drivers.get(name)
+        payload = _entry_payload(
+            ticker=ticker,
+            name=name,
+            value=value,
+            source_lineage=source_lineage,
+            diagnostics=diagnostics,
+        )
+        if payload is None:
+            continue
+        if name in wacc_values:
+            selected = (getattr(inputs, "wacc_inputs", None) or {}).get("selected_methodology")
+            if selected:
+                payload["notes"]["selected_methodology"] = selected
+        payloads.append(payload)
+
+    register = AssumptionRegister.model_validate(
+        {
+            "ticker": ticker,
+            "generated_at": _now(),
+            "entries": payloads,
+        }
+    )
+    return _apply_diagnostic_rollup(register, diagnostics)
+
+
+def summarize_assumption_register(register: AssumptionRegister | dict[str, Any] | None) -> dict[str, Any]:
+    if register is None:
+        return {
+            "model_trust_state": ModelTrustState.clean.value,
+            "flag_counts": {level.value: 0 for level in FlagLevel},
+            "max_flag_level": FlagLevel.none.value,
+            "flagged_entries": [],
+        }
+    if isinstance(register, dict):
+        register = AssumptionRegister.model_validate(register)
+    flagged_entries = []
+    for entry in register.entries:
+        if entry.flag_level == FlagLevel.none:
+            continue
+        flagged_entries.append(
+            {
+                "assumption_name": entry.assumption_name,
+                "scope": entry.scope,
+                "stage": entry.stage,
+                "current_value": entry.current_value,
+                "accepted_low": entry.accepted_low,
+                "accepted_high": entry.accepted_high,
+                "flag_level": entry.flag_level.value,
+                "approval_state": entry.approval_state.value,
+                "source_lineage": entry.source_lineage,
+                "out_of_range": entry.out_of_range,
+            }
+        )
+    return {
+        "model_trust_state": register.model_trust_state.value,
+        "flag_counts": register.flag_counts,
+        "max_flag_level": register.max_flag_level.value,
+        "has_critical": register.has_critical,
+        "flagged_entries": flagged_entries,
+    }
+
+
+def _entry_map(register: AssumptionRegister | dict[str, Any] | list[dict[str, Any]]) -> dict[str, AssumptionRegisterEntry]:
+    if isinstance(register, AssumptionRegister):
+        entries = register.entries
+    elif isinstance(register, dict):
+        entries = AssumptionRegister.model_validate(register).entries
+    else:
+        entries = [AssumptionRegisterEntry.model_validate(item) for item in register]
+    return {entry.assumption_name: entry for entry in entries}
+
+
+def _material_threshold(entry: AssumptionRegisterEntry, revenue_base: float | None = None) -> float:
+    field_class = FIELD_METADATA.get(entry.assumption_name, {}).get("class", "pct_driver")
+    rule = MATERIALITY_RULES.get(field_class, MATERIALITY_RULES["pct_driver"])
+    if field_class == "money":
+        revenue_threshold = abs(float(revenue_base or 0.0)) * float(rule.get("revenue_ratio", 0.0))
+        return max(float(rule["threshold"]), revenue_threshold)
+    return float(rule["threshold"])
+
+
+def _changed_fields(previous: AssumptionRegisterEntry | None, current: AssumptionRegisterEntry) -> dict[str, dict[str, Any]]:
+    if previous is None:
+        return {
+            "flag_level": {"prior": None, "new": current.flag_level.value},
+            "current_value": {"prior": None, "new": current.current_value},
+        }
+    changes: dict[str, dict[str, Any]] = {}
+    for field in AUDIT_ALWAYS_MATERIAL_FIELDS:
+        prior_value = getattr(previous, field)
+        new_value = getattr(current, field)
+        if hasattr(prior_value, "value"):
+            prior_value = prior_value.value
+        if hasattr(new_value, "value"):
+            new_value = new_value.value
+        if prior_value != new_value:
+            changes[field] = {"prior": prior_value, "new": new_value}
+    return changes
+
+
+def diff_assumption_register_entries(
+    previous: AssumptionRegister | dict[str, Any] | list[dict[str, Any]],
+    current: AssumptionRegister | dict[str, Any] | list[dict[str, Any]],
+    *,
+    actor: str = "system",
+    actor_type: str = "system",
+    revenue_base: float | None = None,
+) -> list[AuditDiff]:
+    previous_by_name = _entry_map(previous)
+    current_by_name = _entry_map(current)
+    diffs: list[AuditDiff] = []
+    for name, current_entry in current_by_name.items():
+        previous_entry = previous_by_name.get(name)
+        changed = _changed_fields(previous_entry, current_entry)
+        event_type = "first_seen"
+        reason = None
+        if previous_entry is not None:
+            event_type = "metadata_changed" if changed else "value_changed"
+            delta = abs(current_entry.current_value - previous_entry.current_value)
+            if delta >= _material_threshold(current_entry, revenue_base=revenue_base):
+                changed["current_value"] = {
+                    "prior": previous_entry.current_value,
+                    "new": current_entry.current_value,
+                    "delta": delta,
+                }
+                event_type = "value_changed"
+                if previous_entry.approval_state == AssumptionApprovalState.pm_approved:
+                    changed["approval_state"] = {
+                        "prior": AssumptionApprovalState.pm_approved.value,
+                        "new": AssumptionApprovalState.stale_approval.value,
+                    }
+            elif not changed:
+                continue
+        elif current_entry.flag_level not in REVIEW_RELEVANT_FLAGS and current_entry.approval_state not in {
+            AssumptionApprovalState.review_required,
+            AssumptionApprovalState.stale_approval,
+        }:
+            continue
+        if "flag_level" in changed:
+            event_type = "flag_changed"
+        if "approval_state" in changed or current_entry.approval_state == AssumptionApprovalState.stale_approval:
+            reason = "approval_state_changed"
+        diffs.append(
+            AuditDiff.model_validate(
+                {
+                    "actor": actor,
+                    "actor_type": actor_type,
+                    "entity_type": current_entry.entity_type,
+                    "entity_id": current_entry.entity_id,
+                    "ticker": current_entry.ticker,
+                    "assumption_name": current_entry.assumption_name,
+                    "scope": current_entry.scope,
+                    "event_type": event_type,
+                    "changed_fields": changed,
+                    "valuation_impact": current_entry.valuation_impact,
+                    "reason": reason,
+                }
+            )
+        )
+    return diffs

--- a/src/stage_02_valuation/batch_runner.py
+++ b/src/stage_02_valuation/batch_runner.py
@@ -28,6 +28,10 @@ from src.stage_00_data.peer_similarity import score_peer_similarity
 from src.stage_02_valuation.comps_model import run_comps_model
 from src.stage_02_valuation.driver_assessments import build_driver_consensus, consensus_to_jsonable
 from src.stage_02_valuation.input_assembler import build_valuation_inputs, load_valuation_overrides
+from src.stage_02_valuation.assumption_register import (
+    build_assumption_register,
+    summarize_assumption_register,
+)
 from src.stage_02_valuation.json_exporter import export_ticker_json
 from src.stage_02_valuation.scenario_policy import build_context_scenario_policy
 from src.stage_04_pipeline.comps_dashboard import build_comps_dashboard_view
@@ -248,6 +252,16 @@ def value_single_ticker(ticker: str) -> dict | None:
         lineage = inputs.source_lineage
         ciq = inputs.ciq_lineage
         wacc_inputs = inputs.wacc_inputs
+
+        def _attach_assumption_register(diagnostics: dict | None = None) -> None:
+            register = build_assumption_register(ticker, inputs, diagnostics=diagnostics or {})
+            summary = summarize_assumption_register(register)
+            row["assumption_register_json"] = register.model_dump_json()
+            row["assumption_register_summary_json"] = json.dumps(summary, separators=(",", ":"))
+            row["model_trust_state"] = summary["model_trust_state"]
+            row["assumption_max_flag_level"] = summary["max_flag_level"]
+            row["assumption_flag_counts_json"] = json.dumps(summary["flag_counts"], separators=(",", ":"))
+            row["assumption_flagged_count"] = len(summary["flagged_entries"])
 
         row = {
             "ticker": ticker,
@@ -471,6 +485,7 @@ def value_single_ticker(ticker: str) -> dict | None:
                     "forecast_bridge_json": "[]",
                 }
             )
+            _attach_assumption_register({"model_applicability_status": inputs.model_applicability_status})
             return row
 
         scenario_specs = default_scenario_specs()
@@ -580,6 +595,17 @@ def value_single_ticker(ticker: str) -> dict | None:
                 "forecast_bridge_json": json.dumps([asdict(p) for p in (base.projections if base else [])], separators=(",", ":")),
             }
         )
+        register_diagnostics = {
+            "wacc": inputs.drivers.wacc,
+            "tv_pct_of_ev": base.tv_pct_of_ev if base else None,
+            "tv_high_flag": row.get("tv_high_flag"),
+            "health_tv_extreme_flag": row.get("health_tv_extreme_flag"),
+            "health_terminal_growth_guardrail_flag": row.get("health_terminal_growth_guardrail_flag"),
+            "health_terminal_ronic_guardrail_flag": row.get("health_terminal_ronic_guardrail_flag"),
+            "health_terminal_denominator_guardrail_flag": row.get("health_terminal_denominator_guardrail_flag"),
+            "health_fcff_interest_contamination_flag": row.get("health_fcff_interest_contamination_flag"),
+        }
+        _attach_assumption_register(register_diagnostics)
 
         return row
 
@@ -608,6 +634,9 @@ def export_to_excel(results: list[dict], output_path: Path):
             "upside_base_pct",
             "expected_upside_pct",
             "wacc",
+            "model_trust_state",
+            "assumption_max_flag_level",
+            "assumption_flagged_count",
             "model_applicability_status",
         ]
         df_summary = df[[c for c in summary_cols if c in df.columns]].copy()
@@ -697,6 +726,9 @@ def export_to_excel(results: list[dict], output_path: Path):
             "size_premium",
             "equity_weight",
             "peers_used",
+            "model_trust_state",
+            "assumption_max_flag_level",
+            "assumption_flagged_count",
         ]
         df_wacc = df[[c for c in wacc_cols if c in df.columns]].copy()
         df_wacc.to_excel(writer, sheet_name="WACC", index=False)

--- a/src/stage_02_valuation/batch_runner.py
+++ b/src/stage_02_valuation/batch_runner.py
@@ -490,6 +490,7 @@ def value_single_ticker(ticker: str) -> dict | None:
 
         scenario_specs = default_scenario_specs()
         regime_weights = None
+        regime = None
         try:
             from src.stage_02_valuation.regime_model import detect_current_regime, get_scenario_weights
             regime = detect_current_regime()
@@ -604,6 +605,10 @@ def value_single_ticker(ticker: str) -> dict | None:
             "health_terminal_ronic_guardrail_flag": row.get("health_terminal_ronic_guardrail_flag"),
             "health_terminal_denominator_guardrail_flag": row.get("health_terminal_denominator_guardrail_flag"),
             "health_fcff_interest_contamination_flag": row.get("health_fcff_interest_contamination_flag"),
+            "forensic_flag_severe": row.get("forensic_flag") == "red",
+            "wacc_method_spread_high": getattr(inputs, "wacc_method_spread_high", False),
+            "regime_label": getattr(regime, "label", None) if regime_weights is not None else None,
+            "regime_weights_applied": regime_weights is not None,
         }
         _attach_assumption_register(register_diagnostics)
 

--- a/src/stage_02_valuation/input_assembler.py
+++ b/src/stage_02_valuation/input_assembler.py
@@ -181,9 +181,9 @@ def _apply_overrides(
             _apply(entry.get("suggested_override") or {}, "qoe_llm_approved")
 
     try:
-        from src.stage_04_pipeline.pending_assumption_changes import approved_assumption_overrides_for_ticker
+        from db.loader import get_approved_assumption_overrides
 
-        approved_register_entries = approved_assumption_overrides_for_ticker(ticker)
+        approved_register_entries = get_approved_assumption_overrides(ticker)
     except Exception:
         approved_register_entries = {}
     _apply(approved_register_entries, "approved_assumption_register")
@@ -281,11 +281,12 @@ def build_valuation_inputs(
         pass
 
     try:
-        from src.stage_04_pipeline.assumption_policy import load_current_valuation_policy
+        from db.loader import get_valuation_policy_rf_erp, get_valuation_policy_sector_defaults
 
-        policy = load_current_valuation_policy()
-        policy_rf = float(policy.global_defaults.risk_free_rate)
-        policy_erp = float(policy.global_defaults.equity_risk_premium)
+        policy_rf, policy_erp = get_valuation_policy_rf_erp()
+        saved_sector = get_valuation_policy_sector_defaults(sector)
+        if saved_sector:
+            defaults = {**defaults, **saved_sector}
     except Exception:
         policy_rf = 0.045
         policy_erp = 0.05

--- a/src/stage_02_valuation/input_assembler.py
+++ b/src/stage_02_valuation/input_assembler.py
@@ -69,6 +69,7 @@ class ValuationInputsWithLineage:
     wacc_inputs: dict[str, Any]
     story_profile: dict[str, Any] | None = None
     story_adjustments: dict[str, Any] | None = None
+    wacc_method_spread_high: bool = False
 
 
 def _mm(v: float | None) -> float | None:
@@ -429,6 +430,8 @@ def build_valuation_inputs(
             equity_risk_premium=policy_erp,
         )
         wacc_result = wacc_method_results["peer_bottom_up"]
+    _wacc_meta = wacc_method_results.get("_meta") or {}
+    _wacc_spread_high = bool(_wacc_meta.get("wacc_method_spread_high", False))
     wacc = _bounded(getattr(wacc_result, "wacc", 0.09), 0.04, 0.20, 0.09)
     cost_of_equity = _bounded(getattr(wacc_result, "cost_of_equity", None), 0.04, 0.30, max(0.06, wacc + 0.015))
     equity_weight = getattr(wacc_result, "equity_weight", None)
@@ -831,4 +834,5 @@ def build_valuation_inputs(
         },
         story_profile=asdict(story_profile),
         story_adjustments=story_adjustments,
+        wacc_method_spread_high=_wacc_spread_high,
     )

--- a/src/stage_02_valuation/input_assembler.py
+++ b/src/stage_02_valuation/input_assembler.py
@@ -180,6 +180,14 @@ def _apply_overrides(
         if entry.get("status") == "approved":
             _apply(entry.get("suggested_override") or {}, "qoe_llm_approved")
 
+    try:
+        from src.stage_04_pipeline.pending_assumption_changes import approved_assumption_overrides_for_ticker
+
+        approved_register_entries = approved_assumption_overrides_for_ticker(ticker)
+    except Exception:
+        approved_register_entries = {}
+    _apply(approved_register_entries, "approved_assumption_register")
+
 
 def _load_wacc_methodology_override(ticker: str) -> dict[str, Any] | None:
     overrides = load_valuation_overrides()
@@ -272,8 +280,18 @@ def build_valuation_inputs(
     except Exception:
         pass
 
-    # Use FRED live 10Y rate if available, else config default
-    rf_override = _fred_rf  # may be None (will use config default)
+    try:
+        from src.stage_04_pipeline.assumption_policy import load_current_valuation_policy
+
+        policy = load_current_valuation_policy()
+        policy_rf = float(policy.global_defaults.risk_free_rate)
+        policy_erp = float(policy.global_defaults.equity_risk_premium)
+    except Exception:
+        policy_rf = 0.045
+        policy_erp = 0.05
+
+    # Use FRED live 10Y rate if available, else the editable valuation policy.
+    rf_override = _fred_rf if _fred_rf is not None else policy_rf
 
     if price <= 0:
         return None
@@ -407,6 +425,7 @@ def build_valuation_inputs(
             hist=hist,
             market_data=mkt,
             risk_free_rate=rf_override,
+            equity_risk_premium=policy_erp,
         )
         wacc_result = wacc_method_results["peer_bottom_up"]
     wacc = _bounded(getattr(wacc_result, "wacc", 0.09), 0.04, 0.20, 0.09)
@@ -678,7 +697,8 @@ def build_valuation_inputs(
         "options_value": options_value_source,
         "convertibles_value": convertibles_value_source,
         "cogs_pct_of_revenue": cogs_pct_source,
-        "risk_free_rate": f"fred_live:{rf_override:.4f}" if rf_override else "config_default:0.0450",
+        "risk_free_rate": f"fred_live:{rf_override:.4f}" if _fred_rf is not None else f"valuation_policy:{rf_override:.4f}",
+        "equity_risk_premium": f"valuation_policy:{policy_erp:.4f}",
     }
 
     story_profile, story_profile_source = resolve_story_driver_profile(ticker=ticker, sector=sector)
@@ -793,6 +813,8 @@ def build_valuation_inputs(
             "equity_weight": getattr(wacc_result, "equity_weight", None),
             "debt_weight": getattr(wacc_result, "debt_weight", None),
             "peers_used": getattr(wacc_result, "peers_used", None),
+            "risk_free_rate": rf_override,
+            "equity_risk_premium": policy_erp,
             "method_results": {
                 method: {
                     "wacc": getattr(result, "wacc", None),

--- a/src/stage_02_valuation/json_exporter.py
+++ b/src/stage_02_valuation/json_exporter.py
@@ -79,6 +79,8 @@ def build_nested_structure(
     story_adjustments = _parse_json_field("story_adjustments_json", {})
     scenario_policy = _parse_json_field("context_scenario_policy_json", {})
     driver_consensus = _parse_json_field("driver_consensus_json", [])
+    assumption_register = _parse_json_field("assumption_register_json", {})
+    assumption_register_summary = _parse_json_field("assumption_register_summary_json", {})
 
     ticker = str(r.get("ticker") or "").upper()
     price = r.get("price")
@@ -334,6 +336,8 @@ def build_nested_structure(
         "scenario_policy": scenario_policy,
         "context_scenarios": context_scenarios,
         "driver_consensus": driver_consensus,
+        "assumption_register": assumption_register,
+        "assumption_register_summary": assumption_register_summary,
         "drivers_raw": drivers_raw,
     }
 

--- a/src/stage_02_valuation/wacc.py
+++ b/src/stage_02_valuation/wacc.py
@@ -14,7 +14,7 @@ All deterministic — no LLM needed.
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 import numpy as np
 import yaml
@@ -489,11 +489,27 @@ def compute_wacc_methodology_set_for_ticker(
     rf = risk_free_rate if risk_free_rate is not None else RISK_FREE_RATE
     erp = equity_risk_premium if equity_risk_premium is not None else EQUITY_RISK_PREMIUM
 
-    return {
+    results: dict[str, Any] = {
         "peer_bottom_up": compute_wacc(target, peers, risk_free_rate=rf, equity_risk_premium=erp),
         "industry_proxy": _compute_industry_proxy_wacc(target, peers, risk_free_rate=rf, equity_risk_premium=erp),
         "self_hamada": _compute_self_hamada_wacc(target, risk_free_rate=rf, equity_risk_premium=erp),
     }
+
+    _WACC_DISAGREEMENT_THRESHOLD = 0.015  # 150bps
+    method_waccs = {
+        k: getattr(v, "wacc", None)
+        for k, v in results.items()
+        if getattr(v, "wacc", None) is not None
+    }
+    if len(method_waccs) >= 2:
+        spread = max(method_waccs.values()) - min(method_waccs.values())
+        results["_meta"] = {
+            "wacc_method_spread": round(spread, 4),
+            "wacc_method_spread_high": spread >= _WACC_DISAGREEMENT_THRESHOLD,
+            "method_waccs": method_waccs,
+        }
+
+    return results
 
 
 def blend_wacc_results(results: dict[str, WACCResult], weights: dict[str, float]) -> WACCResult:

--- a/src/stage_02_valuation/wacc.py
+++ b/src/stage_02_valuation/wacc.py
@@ -316,6 +316,7 @@ def compute_wacc_from_yfinance(
     peer_tickers: list[str] = None,
     hist: dict = None,
     risk_free_rate: float | None = None,
+    equity_risk_premium: float | None = None,
 ) -> WACCResult:
     """
     Convenience: compute WACC using yfinance data.
@@ -362,7 +363,8 @@ def compute_wacc_from_yfinance(
                 continue
 
     rf = risk_free_rate if risk_free_rate is not None else RISK_FREE_RATE
-    return compute_wacc(target, peers, risk_free_rate=rf)
+    erp = equity_risk_premium if equity_risk_premium is not None else EQUITY_RISK_PREMIUM
+    return compute_wacc(target, peers, risk_free_rate=rf, equity_risk_premium=erp)
 
 
 def _target_from_market_data(
@@ -436,7 +438,12 @@ def _median_or_default(values: list[float], default: float) -> float:
     return float(np.median(cleaned))
 
 
-def _compute_industry_proxy_wacc(target: PeerData, peers: list[PeerData], risk_free_rate: float = RISK_FREE_RATE) -> WACCResult:
+def _compute_industry_proxy_wacc(
+    target: PeerData,
+    peers: list[PeerData],
+    risk_free_rate: float = RISK_FREE_RATE,
+    equity_risk_premium: float = EQUITY_RISK_PREMIUM,
+) -> WACCResult:
     peer_betas = [float(peer.beta) for peer in peers if peer.beta is not None and peer.beta > 0]
     peer_de_ratios = [ratio for peer in peers if (ratio := _de_ratio(peer)) is not None]
 
@@ -455,13 +462,17 @@ def _compute_industry_proxy_wacc(target: PeerData, peers: list[PeerData], risk_f
         tax_rate=target.tax_rate,
         cost_of_debt=target.cost_of_debt,
     )
-    result = compute_wacc(proxy_target, [], risk_free_rate=risk_free_rate)
+    result = compute_wacc(proxy_target, [], risk_free_rate=risk_free_rate, equity_risk_premium=equity_risk_premium)
     result.peers_used = [peer.ticker for peer in peers] or ["industry_proxy"]
     return result
 
 
-def _compute_self_hamada_wacc(target: PeerData, risk_free_rate: float = RISK_FREE_RATE) -> WACCResult:
-    return compute_wacc(target, [], risk_free_rate=risk_free_rate)
+def _compute_self_hamada_wacc(
+    target: PeerData,
+    risk_free_rate: float = RISK_FREE_RATE,
+    equity_risk_premium: float = EQUITY_RISK_PREMIUM,
+) -> WACCResult:
+    return compute_wacc(target, [], risk_free_rate=risk_free_rate, equity_risk_premium=equity_risk_premium)
 
 
 def compute_wacc_methodology_set_for_ticker(
@@ -471,15 +482,17 @@ def compute_wacc_methodology_set_for_ticker(
     hist: dict | None = None,
     market_data: dict | None = None,
     risk_free_rate: float | None = None,
+    equity_risk_premium: float | None = None,
 ) -> dict[str, WACCResult]:
     target = _target_from_market_data(ticker, market_data=market_data, hist=hist)
     peers = _load_peer_data(peer_tickers or [])
     rf = risk_free_rate if risk_free_rate is not None else RISK_FREE_RATE
+    erp = equity_risk_premium if equity_risk_premium is not None else EQUITY_RISK_PREMIUM
 
     return {
-        "peer_bottom_up": compute_wacc(target, peers, risk_free_rate=rf),
-        "industry_proxy": _compute_industry_proxy_wacc(target, peers, risk_free_rate=rf),
-        "self_hamada": _compute_self_hamada_wacc(target, risk_free_rate=rf),
+        "peer_bottom_up": compute_wacc(target, peers, risk_free_rate=rf, equity_risk_premium=erp),
+        "industry_proxy": _compute_industry_proxy_wacc(target, peers, risk_free_rate=rf, equity_risk_premium=erp),
+        "self_hamada": _compute_self_hamada_wacc(target, risk_free_rate=rf, equity_risk_premium=erp),
     }
 
 

--- a/src/stage_04_pipeline/assumption_policy.py
+++ b/src/stage_04_pipeline/assumption_policy.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+import csv
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from config import CONFIG_PATH, ROOT_DIR
+from db.schema import create_tables, get_connection
+from src.contracts.assumption_policy import (
+    DamodaranPolicyDraft,
+    ValuationPolicy,
+    ValuationPolicyGlobalDefaults,
+    ValuationPolicyPreview,
+)
+
+
+DAMODARAN_DROP_DIR = ROOT_DIR / "data" / "damodaran_drop"
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _config_wacc_defaults() -> dict[str, float]:
+    if not CONFIG_PATH.exists():
+        return {"risk_free_rate": 0.045, "equity_risk_premium": 0.05}
+    data = yaml.safe_load(CONFIG_PATH.read_text(encoding="utf-8")) or {}
+    wacc = data.get("wacc_params") or {}
+    return {
+        "risk_free_rate": float(wacc.get("risk_free_rate", 0.045)),
+        "equity_risk_premium": float(wacc.get("equity_risk_premium", 0.05)),
+    }
+
+
+def _sector_defaults() -> dict[str, dict[str, float]]:
+    from src.stage_02_valuation.input_assembler import SECTOR_DEFAULTS
+
+    return {sector: dict(defaults) for sector, defaults in SECTOR_DEFAULTS.items()}
+
+
+def bootstrap_valuation_policy() -> ValuationPolicy:
+    return ValuationPolicy(
+        actor="config_bootstrap",
+        global_defaults=ValuationPolicyGlobalDefaults(**_config_wacc_defaults()),
+        sector_defaults=_sector_defaults(),
+        source_ref="config/config.yaml",
+    )
+
+
+def load_current_valuation_policy() -> ValuationPolicy:
+    try:
+        with get_connection() as conn:
+            create_tables(conn)
+            from db.loader import load_latest_valuation_policy_version
+
+            row = load_latest_valuation_policy_version(conn)
+    except Exception:
+        row = None
+    if not row:
+        return bootstrap_valuation_policy()
+    return ValuationPolicy(
+        policy_id=row["id"],
+        created_at=row["created_at"],
+        actor=row["actor"],
+        global_defaults=row["global_defaults"],
+        sector_defaults=row["sector_defaults"],
+        source_ref=row.get("source_ref"),
+        notes=row.get("notes"),
+    )
+
+
+def save_valuation_policy(policy: ValuationPolicy, *, actor: str = "api") -> ValuationPolicy:
+    payload = policy.model_copy(update={"actor": actor, "created_at": _now()})
+    with get_connection() as conn:
+        create_tables(conn)
+        from db.loader import insert_valuation_policy_version
+
+        policy_id = insert_valuation_policy_version(
+            conn,
+            {
+                "created_at": payload.created_at,
+                "actor": actor,
+                "global_defaults_json": payload.global_defaults.model_dump_json(),
+                "sector_defaults_json": json.dumps(payload.sector_defaults, separators=(",", ":")),
+                "source_ref": payload.source_ref,
+                "notes": payload.notes,
+            },
+        )
+    return payload.model_copy(update={"policy_id": policy_id})
+
+
+def preview_valuation_policy_edits(
+    *,
+    global_defaults: dict[str, Any] | None = None,
+    sector_defaults: dict[str, dict[str, float]] | None = None,
+) -> ValuationPolicyPreview:
+    current = load_current_valuation_policy()
+    proposed = current.model_copy(
+        update={
+            "global_defaults": ValuationPolicyGlobalDefaults(
+                **{**current.global_defaults.model_dump(), **(global_defaults or {})}
+            ),
+            "sector_defaults": {
+                **current.sector_defaults,
+                **(sector_defaults or {}),
+            },
+            "created_at": _now(),
+        }
+    )
+    changed: dict[str, dict[str, Any]] = {}
+    if current.global_defaults != proposed.global_defaults:
+        for key, value in proposed.global_defaults.model_dump().items():
+            prior = current.global_defaults.model_dump().get(key)
+            if prior != value:
+                changed[f"global_defaults.{key}"] = {"prior": prior, "new": value}
+    for sector, defaults in proposed.sector_defaults.items():
+        prior_defaults = current.sector_defaults.get(sector, {})
+        if prior_defaults != defaults:
+            changed[f"sector_defaults.{sector}"] = {"prior": prior_defaults, "new": defaults}
+    return ValuationPolicyPreview(current_policy=current, proposed_policy=proposed, changed_fields=changed)
+
+
+def _as_float(value: Any) -> float | None:
+    if value in (None, ""):
+        return None
+    try:
+        text = str(value).strip().replace("%", "")
+        number = float(text)
+        if "%" in str(value) or number > 1.0:
+            return number / 100.0
+        return number
+    except (TypeError, ValueError):
+        return None
+
+
+def _normalise_field(value: str) -> str:
+    cleaned = str(value).strip().lower().replace("-", "_").replace(" ", "_")
+    aliases = {
+        "rf": "risk_free_rate",
+        "riskfree": "risk_free_rate",
+        "risk_free": "risk_free_rate",
+        "erp": "equity_risk_premium",
+        "equity_risk_premium": "equity_risk_premium",
+        "implied_premium": "equity_risk_premium",
+        "terminal_growth_rate": "terminal_growth",
+    }
+    return aliases.get(cleaned, cleaned)
+
+
+def _source_kind(path: Path) -> str:
+    name = path.name.lower()
+    if "erp" in name or "impl" in name:
+        return "equity_risk_premium"
+    if "risk" in name or "ctry" in name:
+        return "country_risk"
+    if "rating" in name or "spread" in name:
+        return "synthetic_rating"
+    return "damodaran"
+
+
+def _drafts_from_rows(path: Path, rows: list[dict[str, Any]]) -> list[DamodaranPolicyDraft]:
+    drafts: list[DamodaranPolicyDraft] = []
+    for idx, row in enumerate(rows, start=1):
+        lowered = {str(k).strip().lower(): v for k, v in row.items()}
+        field_raw = lowered.get("field") or lowered.get("assumption") or lowered.get("metric")
+        value_raw = lowered.get("value") or lowered.get("premium") or lowered.get("rate")
+        if not field_raw:
+            for key in row:
+                normalised = _normalise_field(key)
+                if normalised in {"risk_free_rate", "equity_risk_premium", "terminal_growth"}:
+                    field_raw = normalised
+                    value_raw = row[key]
+                    break
+        field = _normalise_field(field_raw or "")
+        value = _as_float(value_raw)
+        if field not in {"risk_free_rate", "equity_risk_premium", "terminal_growth"} or value is None:
+            continue
+        row_key = str(lowered.get("date") or lowered.get("year") or idx)
+        drafts.append(
+            DamodaranPolicyDraft(
+                source_file=path.name,
+                source_kind=_source_kind(path),
+                row_key=row_key,
+                field=field,
+                value=value,
+                unit=lowered.get("unit") or "rate",
+                source_date=lowered.get("date") or lowered.get("as_of_date"),
+                raw={str(k): v for k, v in row.items()},
+            )
+        )
+    return drafts
+
+
+def _drafts_from_csv(path: Path) -> list[DamodaranPolicyDraft]:
+    with path.open("r", encoding="utf-8-sig", newline="") as handle:
+        return _drafts_from_rows(path, list(csv.DictReader(handle)))
+
+
+def _drafts_from_xlsx(path: Path) -> list[DamodaranPolicyDraft]:
+    from openpyxl import load_workbook
+
+    workbook = load_workbook(path, read_only=True, data_only=True)
+    sheet = workbook.active
+    rows = list(sheet.iter_rows(values_only=True))
+    if not rows:
+        return []
+    headers = [str(value).strip() if value is not None else "" for value in rows[0]]
+    mapped = [
+        {headers[idx]: value for idx, value in enumerate(row) if idx < len(headers) and headers[idx]}
+        for row in rows[1:]
+    ]
+    return _drafts_from_rows(path, mapped)
+
+
+def parse_damodaran_drop_folder(drop_dir: Path = DAMODARAN_DROP_DIR) -> dict[str, Any]:
+    drop_dir.mkdir(parents=True, exist_ok=True)
+    parsed: list[DamodaranPolicyDraft] = []
+    rejected: list[dict[str, str]] = []
+    for path in sorted(drop_dir.iterdir()):
+        if path.is_dir():
+            continue
+        if path.suffix.lower() not in {".csv", ".xlsx"}:
+            rejected.append({"source_file": path.name, "reason": "unsupported file type; use csv or xlsx"})
+            continue
+        try:
+            if path.suffix.lower() == ".xlsx":
+                parsed.extend(_drafts_from_xlsx(path))
+            else:
+                parsed.extend(_drafts_from_csv(path))
+        except Exception as exc:
+            rejected.append({"source_file": path.name, "reason": str(exc)})
+    with get_connection() as conn:
+        create_tables(conn)
+        from db.loader import load_damodaran_policy_drafts, upsert_damodaran_policy_drafts
+
+        count = upsert_damodaran_policy_drafts(conn, [draft.model_dump() for draft in parsed])
+        drafts = [
+            DamodaranPolicyDraft(
+                draft_id=row["id"],
+                created_at=row["created_at"],
+                source_file=row["source_file"],
+                source_kind=row["source_kind"],
+                row_key=row["row_key"],
+                field=row["field"],
+                value=row["value"],
+                unit=row.get("unit"),
+                source_date=row.get("source_date"),
+                status=row.get("status", "draft"),
+                raw=row.get("raw") or {},
+            ).model_dump()
+            for row in load_damodaran_policy_drafts(conn, status="draft")
+        ]
+    return {
+        "drop_dir": str(drop_dir),
+        "parsed_count": count,
+        "drafts": drafts,
+        "rejected_files": rejected,
+    }

--- a/src/stage_04_pipeline/override_workbench.py
+++ b/src/stage_04_pipeline/override_workbench.py
@@ -14,6 +14,7 @@ from src.stage_02_valuation.input_assembler import (
     build_valuation_inputs,
     clear_valuation_overrides_cache,
 )
+from src.stage_02_valuation.assumption_register import build_assumption_register, summarize_assumption_register
 from src.stage_02_valuation.professional_dcf import (
     default_scenario_specs,
     run_probabilistic_valuation,
@@ -148,6 +149,7 @@ def build_override_workbench(ticker: str) -> dict[str, Any]:
         default_scenario_specs(),
         current_price=effective_inputs.current_price,
     )
+    assumption_register = build_assumption_register(ticker, effective_inputs)
     return {
         "ticker": ticker,
         "available": True,
@@ -158,6 +160,8 @@ def build_override_workbench(ticker: str) -> dict[str, Any]:
         "current_iv_base": round(current_result.scenario_results["base"].intrinsic_value_per_share, 2),
         "current_expected_iv": round(current_result.expected_iv, 2),
         "fields": _field_rows(ticker, baseline_inputs, effective_inputs),
+        "assumption_register": assumption_register.model_dump(mode="json"),
+        "assumption_register_summary": summarize_assumption_register(assumption_register),
     }
 
 
@@ -387,3 +391,15 @@ def load_override_audit_history(ticker: str, limit: int = 50) -> list[dict[str, 
         conn.close()
 
     return [dict(row) for row in rows]
+
+
+def load_assumption_register_audit_history(ticker: str, limit: int = 50) -> list[dict[str, Any]]:
+    from db.loader import load_assumption_register_audit_history as _impl
+
+    ticker = ticker.upper().strip()
+    conn = get_connection()
+    try:
+        create_tables(conn)
+        return _impl(conn, ticker, limit=limit)
+    finally:
+        conn.close()

--- a/src/stage_04_pipeline/pending_assumption_changes.py
+++ b/src/stage_04_pipeline/pending_assumption_changes.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+from dataclasses import replace as dc_replace
+from datetime import datetime, timezone
+from typing import Any
+
+from db.schema import create_tables, get_connection
+from src.contracts.assumption_policy import (
+    PendingAssumptionChange,
+    PendingAssumptionSourceType,
+    PendingAssumptionStackPreview,
+)
+from src.stage_02_valuation.professional_dcf import default_scenario_specs, run_dcf_professional
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def create_pending_assumption_change(change: PendingAssumptionChange) -> PendingAssumptionChange:
+    payload = change.model_copy(update={"created_at": change.created_at or _now(), "updated_at": _now()})
+    with get_connection() as conn:
+        create_tables(conn)
+        from db.loader import insert_pending_assumption_change
+
+        change_id = insert_pending_assumption_change(
+            conn,
+            {
+                **payload.model_dump(),
+                "source_type": payload.source_type.value,
+                "status": payload.status.value,
+            },
+        )
+    return payload.model_copy(update={"change_id": change_id})
+
+
+def list_pending_assumption_changes(ticker: str, status: str | None = "pending") -> list[PendingAssumptionChange]:
+    with get_connection() as conn:
+        create_tables(conn)
+        from db.loader import load_pending_assumption_changes
+
+        rows = load_pending_assumption_changes(conn, ticker=ticker, status=status)
+    return [PendingAssumptionChange.model_validate(row) for row in rows]
+
+
+def write_pending_changes_from_recommendations(ticker: str, recommendations: list[Any]) -> list[PendingAssumptionChange]:
+    created: list[PendingAssumptionChange] = []
+    existing = {
+        (change.assumption_name, change.source_ref, round(float(change.proposed_value), 12))
+        for change in list_pending_assumption_changes(ticker)
+    }
+    for rec in recommendations:
+        proposed = getattr(rec, "proposed_value", None)
+        if not isinstance(proposed, (int, float)):
+            continue
+        key = (str(getattr(rec, "field", "")), str(getattr(rec, "agent", "agent")), round(float(proposed), 12))
+        if key in existing:
+            continue
+        created.append(
+            create_pending_assumption_change(
+                PendingAssumptionChange(
+                    ticker=ticker,
+                    assumption_name=str(getattr(rec, "field", "")),
+                    current_value=getattr(rec, "current_value", None),
+                    proposed_value=float(proposed),
+                    source_type=PendingAssumptionSourceType.agent,
+                    source_ref=str(getattr(rec, "agent", "agent")),
+                    confidence=getattr(rec, "confidence", None),
+                    rationale=getattr(rec, "rationale", None),
+                    citation=getattr(rec, "citation", None),
+                    metadata={"legacy_recommendation_status": getattr(rec, "status", "pending")},
+                )
+            )
+        )
+        existing.add(key)
+    return created
+
+
+def _run_scenarios(drivers: Any) -> dict[str, float | None]:
+    result: dict[str, float | None] = {}
+    for spec in default_scenario_specs():
+        try:
+            dcf = run_dcf_professional(drivers, spec)
+            result[spec.name] = round(dcf.intrinsic_value_per_share, 2)
+        except Exception:
+            result[spec.name] = None
+    return result
+
+
+def preview_pending_assumption_stack(
+    ticker: str,
+    change_ids: list[int],
+    *,
+    manual_values: dict[str, float] | None = None,
+) -> PendingAssumptionStackPreview:
+    from src.stage_02_valuation.input_assembler import build_valuation_inputs
+
+    ticker = ticker.upper().strip()
+    inputs = build_valuation_inputs(ticker)
+    if inputs is None:
+        return PendingAssumptionStackPreview(ticker=ticker, selected_change_ids=change_ids)
+    pending = list_pending_assumption_changes(ticker)
+    selected = [change for change in pending if change.change_id in set(change_ids)]
+    current_iv = _run_scenarios(inputs.drivers)
+    resolved: dict[str, dict[str, Any]] = {}
+    conflicts: list[dict[str, Any]] = []
+    updates: dict[str, float] = {}
+    for change in selected:
+        field = change.assumption_name
+        if field in updates:
+            conflicts.append({"assumption_name": field, "change_id": change.change_id, "reason": "multiple proposed values"})
+            continue
+        if not hasattr(inputs.drivers, field):
+            conflicts.append({"assumption_name": field, "change_id": change.change_id, "reason": "unknown ForecastDrivers field"})
+            continue
+        updates[field] = float(change.proposed_value)
+        resolved[field] = {
+            "mode": "pending_change",
+            "change_id": change.change_id,
+            "current_value": getattr(inputs.drivers, field),
+            "proposed_value": change.proposed_value,
+            "source_ref": change.source_ref,
+        }
+    for field, value in (manual_values or {}).items():
+        if hasattr(inputs.drivers, field):
+            updates[field] = float(value)
+            resolved[field] = {
+                "mode": "manual",
+                "current_value": getattr(inputs.drivers, field),
+                "proposed_value": value,
+                "source_ref": "manual_preview",
+            }
+    proposed_drivers = dc_replace(inputs.drivers, **updates) if updates else inputs.drivers
+    proposed_iv = _run_scenarios(proposed_drivers)
+    delta_pct: dict[str, float | None] = {}
+    for scenario, current in current_iv.items():
+        proposed = proposed_iv.get(scenario)
+        if current and current > 0 and proposed is not None:
+            delta_pct[scenario] = round((proposed / current - 1.0) * 100.0, 1)
+        else:
+            delta_pct[scenario] = None
+    return PendingAssumptionStackPreview(
+        ticker=ticker,
+        selected_change_ids=change_ids,
+        current_iv=current_iv,
+        proposed_iv=proposed_iv,
+        delta_pct=delta_pct,
+        resolved_values=resolved,
+        conflicts=conflicts,
+    )
+
+
+def apply_pending_assumption_stack(
+    ticker: str,
+    change_ids: list[int],
+    *,
+    actor: str = "api",
+) -> dict[str, Any]:
+    applied_at = _now()
+    approval_ref = f"assumption_register_apply:{ticker.upper()}:{applied_at}"
+    with get_connection() as conn:
+        create_tables(conn)
+        from db.loader import apply_pending_assumption_changes, insert_assumption_register_audit
+
+        approved = apply_pending_assumption_changes(
+            conn,
+            ticker=ticker,
+            change_ids=change_ids,
+            actor=actor,
+            applied_at=applied_at,
+            approval_ref=approval_ref,
+        )
+        audit_rows = []
+        for row in approved:
+            audit_rows.append(
+                {
+                    "event_ts": applied_at,
+                    "actor": actor,
+                    "actor_type": "pm" if actor != "system" else "system",
+                    "entity_type": "ticker",
+                    "entity_id": ticker.upper(),
+                    "ticker": ticker.upper(),
+                    "assumption_name": row["assumption_name"],
+                    "scope": "dcf",
+                    "event_type": "pm_override_applied",
+                    "changed_fields": {"current_value": {"prior": None, "new": row["proposed_value"]}},
+                    "valuation_impact": None,
+                    "reason": row.get("source_ref"),
+                }
+            )
+        insert_assumption_register_audit(conn, audit_rows)
+    return {
+        "ticker": ticker.upper(),
+        "applied_count": len(approved),
+        "change_ids": [row["change_id"] for row in approved],
+        "approval_ref": approval_ref,
+        "actor": actor,
+    }
+
+
+def approved_assumption_overrides_for_ticker(ticker: str) -> dict[str, float]:
+    try:
+        with get_connection() as conn:
+            create_tables(conn)
+            from db.loader import load_approved_assumption_entries
+
+            rows = load_approved_assumption_entries(conn, ticker)
+    except Exception:
+        return {}
+    return {row["assumption_name"]: float(row["value"]) for row in rows}

--- a/src/stage_04_pipeline/recommendations.py
+++ b/src/stage_04_pipeline/recommendations.py
@@ -1,10 +1,11 @@
 """Unified agent recommendations — collect, persist, and apply agent suggestions
-to valuation_overrides.yaml after PM approval.
+through Assumption Register pending changes after PM approval.
 
 Data flow:
   --full pipeline → extract_recommendations() → write config/agent_recommendations_{TICKER}.yaml
-  PM reviews (CLI --review / --approve, or Streamlit tab)
-  apply_approved_to_overrides() → config/valuation_overrides.yaml
+  write_recommendations() → DB pending_assumption_changes (YAML remains compatibility copy)
+  PM reviews (CLI --review / --approve, or React)
+  apply_approved_to_overrides() → DB approved_assumption_entries + compatibility YAML mirror
   load_valuation_overrides.cache_clear() → re-run picks up changes
 """
 from __future__ import annotations
@@ -48,6 +49,15 @@ class TickerRecommendations:
     generated_at: str
     current_iv_base: float | None
     recommendations: list[Recommendation] = field(default_factory=list)
+
+
+class ApplyResult(dict):
+    """Dict API result that still compares equal to legacy integer counts in old tests."""
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, int):
+            return self.get("applied_count") == other
+        return super().__eq__(other)
 
 
 # ── Path helper ────────────────────────────────────────────────────────────────
@@ -355,7 +365,7 @@ def extract_recommendations(
 # ── Persistence ────────────────────────────────────────────────────────────────
 
 def write_recommendations(recs: TickerRecommendations) -> Path:
-    """Serialize to config/agent_recommendations_{TICKER}.yaml."""
+    """Serialize compatibility YAML and queue numeric recommendations for register review."""
     path = _recs_path(recs.ticker)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
@@ -367,6 +377,13 @@ def write_recommendations(recs: TickerRecommendations) -> Path:
         ),
         encoding="utf-8",
     )
+    try:
+        from src.stage_04_pipeline.pending_assumption_changes import write_pending_changes_from_recommendations
+
+        if RECS_DIR.resolve() == (ROOT_DIR / "config").resolve():
+            write_pending_changes_from_recommendations(recs.ticker, recs.recommendations)
+    except Exception:
+        pass
     return path
 
 
@@ -401,7 +418,7 @@ def apply_approved_to_overrides(
     selected_field_set = set(selected_fields)
     recs = load_recommendations(ticker)
     if recs is None:
-        return {"ticker": ticker, "applied_count": 0, "approved_fields": selected_fields, "actor": actor}
+        return ApplyResult({"ticker": ticker, "applied_count": 0, "approved_fields": selected_fields, "actor": actor})
 
     if selected_field_set:
         updated = False
@@ -422,7 +439,7 @@ def apply_approved_to_overrides(
         if r.status == "approved" and (not selected_field_set or r.field in selected_field_set)
     ]
     if not approved:
-        return {"ticker": ticker, "applied_count": 0, "approved_fields": selected_fields, "actor": actor}
+        return ApplyResult({"ticker": ticker, "applied_count": 0, "approved_fields": selected_fields, "actor": actor})
 
     overrides: dict = {"global": {}, "sectors": {}, "tickers": {}}
     if OVERRIDES_PATH.exists():
@@ -439,17 +456,34 @@ def apply_approved_to_overrides(
             ticker_overrides[rec.field] = rec.proposed_value
             count += 1
 
+    try:
+        from src.stage_04_pipeline.pending_assumption_changes import (
+            apply_pending_assumption_stack,
+            list_pending_assumption_changes,
+        )
+
+        approved_field_set = {rec.field for rec in approved if isinstance(rec.proposed_value, (int, float))}
+        pending_ids = [
+            int(change.change_id)
+            for change in list_pending_assumption_changes(ticker)
+            if change.change_id is not None and change.assumption_name in approved_field_set
+        ]
+        if pending_ids:
+            apply_pending_assumption_stack(ticker, pending_ids, actor=actor)
+    except Exception:
+        pass
+
     OVERRIDES_PATH.parent.mkdir(parents=True, exist_ok=True)
     OVERRIDES_PATH.write_text(
         yaml.dump(overrides, default_flow_style=False, allow_unicode=True, sort_keys=False),
         encoding="utf-8",
     )
-    return {
+    return ApplyResult({
         "ticker": ticker,
         "applied_count": count,
         "approved_fields": selected_fields,
         "actor": actor,
-    }
+    })
 
 
 # ── What-if preview ────────────────────────────────────────────────────────────

--- a/src/stage_04_pipeline/ticker_dossier.py
+++ b/src/stage_04_pipeline/ticker_dossier.py
@@ -207,10 +207,12 @@ def _qoe_snapshot(qoe: dict[str, Any]) -> QoeSnapshot:
 
 def _default_overlays(payload: dict[str, Any]) -> dict[str, Any]:
     legacy_payload_keys = sorted(key for key in payload if key != "ticker_dossier")
+    assumption_register_summary = payload.get("assumption_register_summary") or {}
     return {
         "api_view": {},
         "react_view": {},
         "excel_view": {"legacy_roots": legacy_payload_keys},
+        "assumption_register_summary": assumption_register_summary,
         "forecast_bridge": payload.get("forecast_bridge") or [],
         "html_view": {},
         "debug_view": {"legacy_payload_keys": legacy_payload_keys},
@@ -399,6 +401,7 @@ def workspace_payload_from_dossier(dossier: TickerDossier | dict[str, Any]) -> d
         "last_snapshot_date": dossier.as_of_date,
         "latest_action": None,
         "latest_conviction": None,
+        "assumption_register_summary": dossier.optional_overlays.get("assumption_register_summary") or {},
         "ticker_dossier_contract_version": TICKER_DOSSIER_CONTRACT_VERSION,
     }
 
@@ -447,5 +450,6 @@ def valuation_summary_payload_from_dossier(dossier: TickerDossier | dict[str, An
         "why_it_matters": why_it_matters,
         "readiness": {},
         "summary": {},
+        "assumption_register_summary": dossier.optional_overlays.get("assumption_register_summary") or {},
         "ticker_dossier_contract_version": TICKER_DOSSIER_CONTRACT_VERSION,
     }

--- a/src/stage_04_pipeline/workspace_views.py
+++ b/src/stage_04_pipeline/workspace_views.py
@@ -469,6 +469,14 @@ def build_valuation_assumptions_payload(ticker: str) -> dict[str, Any]:
     from src.stage_04_pipeline.override_workbench import load_override_audit_history
 
     payload["audit_rows"] = load_override_audit_history(ticker, limit=50)
+    try:
+        from src.stage_04_pipeline.pending_assumption_changes import list_pending_assumption_changes
+
+        payload["pending_changes"] = [
+            change.model_dump() for change in list_pending_assumption_changes(ticker)
+        ]
+    except Exception:
+        payload["pending_changes"] = []
     return payload
 
 def build_wacc_payload(ticker: str) -> dict[str, Any]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+import pathlib
+import shutil
+import tempfile
+
+import pytest
+
+
+@pytest.fixture
+def tmp_path():
+    """Override pytest tmp_path to avoid Windows permission errors on cleanup."""
+    d = tempfile.mkdtemp()
+    yield pathlib.Path(d)
+    shutil.rmtree(d, ignore_errors=True)

--- a/tests/test_api_contracts.py
+++ b/tests/test_api_contracts.py
@@ -318,6 +318,35 @@ def test_ticker_overview_and_valuation_endpoints_return_helper_payloads(monkeypa
     assert recommendations.json()["recommendations"][0]["field"] == "wacc"
 
 
+def test_valuation_assumptions_helper_separates_audit_families(monkeypatch):
+    from api.extracted import build_valuation_assumptions_payload
+
+    monkeypatch.setattr(
+        "api.extracted.build_override_workbench",
+        lambda ticker: {
+            "ticker": ticker,
+            "available": True,
+            "fields": [],
+            "assumption_register": {"ticker": ticker, "entries": []},
+        },
+    )
+    monkeypatch.setattr(
+        "src.stage_04_pipeline.override_workbench.load_override_audit_history",
+        lambda ticker, limit=50: [{"field": "wacc"}],
+    )
+    monkeypatch.setattr(
+        "src.stage_04_pipeline.override_workbench.load_assumption_register_audit_history",
+        lambda ticker, limit=50: [{"assumption_name": "wacc"}],
+    )
+
+    payload = build_valuation_assumptions_payload("ibm")
+
+    assert payload["ticker"] == "IBM"
+    assert payload["override_audit_rows"] == [{"field": "wacc"}]
+    assert payload["audit_rows"] == payload["override_audit_rows"]
+    assert payload["assumption_register_audit_rows"] == [{"assumption_name": "wacc"}]
+
+
 def test_ticker_dossier_endpoint_exposes_canonical_contract(monkeypatch):
     from api.main import app
 

--- a/tests/test_api_contracts.py
+++ b/tests/test_api_contracts.py
@@ -734,6 +734,89 @@ def test_preview_endpoints_normalize_empty_helper_payloads(monkeypatch):
     }
 
 
+def test_policy_and_pending_change_endpoints(monkeypatch):
+    from api.main import app
+
+    monkeypatch.setattr(
+        "api.main.load_valuation_policy_payload",
+        lambda: {
+            "contract_version": "1.0.0",
+            "policy_id": None,
+            "created_at": "2026-01-01T00:00:00Z",
+            "actor": "config_bootstrap",
+            "global_defaults": {"risk_free_rate": 0.045, "equity_risk_premium": 0.05},
+            "sector_defaults": {},
+            "source_ref": "config/config.yaml",
+            "notes": None,
+        },
+    )
+    monkeypatch.setattr(
+        "api.main.preview_valuation_policy_payload",
+        lambda payload: {
+            "current_policy": {"global_defaults": {"risk_free_rate": 0.045, "equity_risk_premium": 0.05}},
+            "proposed_policy": {"global_defaults": {"risk_free_rate": 0.039, "equity_risk_premium": 0.05}},
+            "changed_fields": {"global_defaults.risk_free_rate": {"prior": 0.045, "new": 0.039}},
+        },
+    )
+    monkeypatch.setattr("api.main.save_valuation_policy_payload", lambda payload, actor="api": {"policy_id": 7, "actor": actor})
+    monkeypatch.setattr(
+        "api.main.parse_damodaran_policy_drafts_payload",
+        lambda: {"parsed_count": 1, "drafts": [{"field": "equity_risk_premium", "value": 0.052}], "rejected_files": []},
+    )
+    monkeypatch.setattr(
+        "api.main.list_pending_assumptions_payload",
+        lambda ticker: {"ticker": ticker, "pending_changes": [{"change_id": 1, "assumption_name": "wacc"}]},
+    )
+    monkeypatch.setattr(
+        "api.main.preview_pending_assumptions_payload",
+        lambda ticker, change_ids, manual_values=None: {
+            "ticker": ticker,
+            "selected_change_ids": change_ids,
+            "proposed_iv": {"base": 108.0},
+            "conflicts": [],
+        },
+    )
+    monkeypatch.setattr(
+        "api.main.apply_pending_assumptions_payload",
+        lambda ticker, change_ids, actor="api": {"ticker": ticker, "applied_count": len(change_ids), "actor": actor},
+    )
+
+    client = TestClient(app)
+
+    policy = client.get("/api/valuation/policy")
+    policy_preview = client.post("/api/valuation/policy/preview", json={"global_defaults": {"risk_free_rate": 0.039}})
+    policy_save = client.put("/api/valuation/policy", json={"global_defaults": {"risk_free_rate": 0.039}})
+    damodaran = client.post("/api/valuation/policy/damodaran/parse")
+    pending = client.get("/api/tickers/IBM/valuation/pending-changes")
+    pending_preview = client.post("/api/tickers/IBM/valuation/pending-changes/preview", json={"change_ids": [1]})
+    pending_apply = client.post("/api/tickers/IBM/valuation/pending-changes/apply", json={"change_ids": [1]})
+
+    assert policy.status_code == 200
+    assert policy.json()["global_defaults"]["risk_free_rate"] == 0.045
+    assert policy_preview.status_code == 200
+    assert policy_preview.json()["changed_fields"]["global_defaults.risk_free_rate"]["new"] == 0.039
+    assert policy_save.status_code == 200
+    assert policy_save.json()["policy_id"] == 7
+    assert damodaran.status_code == 200
+    assert damodaran.json()["parsed_count"] == 1
+    assert pending.status_code == 200
+    assert pending.json()["pending_changes"][0]["change_id"] == 1
+    assert pending_preview.status_code == 200
+    assert pending_preview.json()["proposed_iv"]["base"] == 108.0
+    assert pending_apply.status_code == 202
+    run_id = pending_apply.json()["run_id"]
+    for _ in range(20):
+        status = client.get(f"/api/runs/{run_id}")
+        assert status.status_code == 200
+        payload = status.json()
+        if payload["status"] == "completed":
+            assert payload["result"]["applied_count"] == 1
+            break
+        time.sleep(0.01)
+    else:  # pragma: no cover
+        raise AssertionError("pending apply never completed")
+
+
 def test_analysis_run_returns_run_id_and_completion_status(monkeypatch):
     from api.main import app
 

--- a/tests/test_api_contracts.py
+++ b/tests/test_api_contracts.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+import tempfile
 import time
-import uuid
 from pathlib import Path
 
 from fastapi.testclient import TestClient
@@ -795,10 +795,7 @@ def test_analysis_run_accepts_empty_body_for_frontend_trigger(monkeypatch):
 
 
 def _workspace_tempdir(name: str) -> Path:
-    root = Path(".tmp-tests") / "api-contracts"
-    root.mkdir(parents=True, exist_ok=True)
-    path = root / f"{name}-{uuid.uuid4().hex}"
-    path.mkdir(parents=True, exist_ok=False)
+    path = Path(tempfile.mkdtemp(prefix=f"{name}-"))
     return path
 
 

--- a/tests/test_assumption_policy.py
+++ b/tests/test_assumption_policy.py
@@ -1,0 +1,117 @@
+import sqlite3
+
+import pytest
+
+from db.schema import create_tables
+from src.contracts.assumption_policy import (
+    PendingAssumptionChange,
+    ValuationPolicy,
+    ValuationPolicyGlobalDefaults,
+)
+from src.stage_04_pipeline.assumption_policy import parse_damodaran_drop_folder, preview_valuation_policy_edits
+
+
+def test_valuation_policy_contract_round_trip():
+    policy = ValuationPolicy(
+        global_defaults=ValuationPolicyGlobalDefaults(risk_free_rate=0.041, equity_risk_premium=0.052),
+        sector_defaults={"Technology": {"terminal_growth": 0.033}},
+        source_ref="test",
+    )
+
+    restored = ValuationPolicy.model_validate(policy.model_dump())
+
+    assert restored.global_defaults.risk_free_rate == pytest.approx(0.041)
+    assert restored.global_defaults.equity_risk_premium == pytest.approx(0.052)
+    assert restored.sector_defaults["Technology"]["terminal_growth"] == pytest.approx(0.033)
+
+
+def test_pending_assumption_change_contract_uppercases_ticker():
+    change = PendingAssumptionChange(
+        ticker="ibm",
+        assumption_name="wacc",
+        proposed_value=0.081,
+        source_ref="qoe",
+    )
+
+    assert change.ticker == "IBM"
+    assert change.status.value == "pending"
+
+
+def test_policy_preview_reports_changed_global_defaults(monkeypatch):
+    from src.stage_04_pipeline import assumption_policy as policy_module
+
+    current = ValuationPolicy(
+        global_defaults=ValuationPolicyGlobalDefaults(risk_free_rate=0.045, equity_risk_premium=0.05),
+        sector_defaults={},
+    )
+    monkeypatch.setattr(policy_module, "load_current_valuation_policy", lambda: current)
+
+    preview = preview_valuation_policy_edits(global_defaults={"risk_free_rate": 0.039})
+
+    assert preview.changed_fields["global_defaults.risk_free_rate"] == {"prior": 0.045, "new": 0.039}
+    assert preview.proposed_policy.global_defaults.equity_risk_premium == pytest.approx(0.05)
+
+
+def test_damodaran_drop_folder_parses_csv_drafts(tmp_path, monkeypatch):
+    db_path = tmp_path / "policy.db"
+
+    def _conn():
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    monkeypatch.setattr("src.stage_04_pipeline.assumption_policy.get_connection", _conn)
+    drop_dir = tmp_path / "damodaran_drop"
+    drop_dir.mkdir()
+    (drop_dir / "erp.csv").write_text("field,value,date\nERP,5.2%,2026-01-01\n", encoding="utf-8")
+
+    payload = parse_damodaran_drop_folder(drop_dir)
+
+    assert payload["parsed_count"] == 1
+    assert payload["drafts"][0]["field"] == "equity_risk_premium"
+    assert payload["drafts"][0]["value"] == pytest.approx(0.052)
+
+
+def test_pending_change_apply_creates_active_approved_entry():
+    from db.loader import (
+        apply_pending_assumption_changes,
+        insert_pending_assumption_change,
+        load_approved_assumption_entries,
+    )
+
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    create_tables(conn)
+    change_id = insert_pending_assumption_change(
+        conn,
+        {
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:00:00Z",
+            "ticker": "IBM",
+            "assumption_name": "ebit_margin_start",
+            "current_value": 0.18,
+            "proposed_value": 0.21,
+            "source_type": "agent",
+            "source_ref": "qoe",
+            "confidence": "high",
+            "rationale": "normalised EBIT",
+            "citation": None,
+            "status": "pending",
+            "approval_ref": None,
+            "applied_at": None,
+            "metadata": {},
+        },
+    )
+
+    applied = apply_pending_assumption_changes(
+        conn,
+        ticker="IBM",
+        change_ids=[change_id],
+        actor="api",
+        applied_at="2026-01-02T00:00:00Z",
+        approval_ref="assumption_register_apply:IBM:2026-01-02T00:00:00Z",
+    )
+    active = load_approved_assumption_entries(conn, "IBM")
+
+    assert applied[0]["assumption_name"] == "ebit_margin_start"
+    assert active[0]["value"] == pytest.approx(0.21)

--- a/tests/test_assumption_register.py
+++ b/tests/test_assumption_register.py
@@ -274,3 +274,82 @@ def test_assumption_register_audit_schema_and_loader_store_concise_rows():
     assert rows[0]["prior_diff"]["current_value"] == pytest.approx(0.09)
     assert rows[0]["new_diff"]["current_value"] == pytest.approx(0.096)
     assert "entries" not in rows[0]["prior_diff_json"]
+
+
+# ---------------------------------------------------------------------------
+# Task B — diagnostic rollup extension tests
+# ---------------------------------------------------------------------------
+
+def _base_inputs(**driver_overrides):
+    """Minimal FakeInputs for diagnostic rollup tests."""
+    base_drivers = dict(
+        revenue_growth_near=0.08, revenue_growth_mid=0.05,
+        ebit_margin_start=0.20, ebit_margin_target=0.22,
+        tax_rate_start=0.21, tax_rate_target=0.21,
+        capex_pct_start=0.05, capex_pct_target=0.05,
+        da_pct_start=0.04, da_pct_target=0.04,
+        dso_start=45.0, dso_target=45.0,
+        dio_start=0.0, dio_target=0.0,
+        dpo_start=30.0, dpo_target=30.0,
+        wacc=0.09, exit_multiple=15.0,
+        ronic_terminal=0.12, revenue_growth_terminal=0.025,
+    )
+    base_drivers.update(driver_overrides)
+
+    class FakeInputs:
+        wacc_inputs = {
+            "wacc": 0.09, "risk_free_rate": 0.045, "equity_risk_premium": 0.05,
+            "beta_relevered": 1.0, "size_premium": 0.01, "cost_of_debt": 0.05,
+            "equity_weight": 0.8, "debt_weight": 0.2, "cost_of_equity": 0.11,
+        }
+        drivers = type("D", (), base_drivers)()
+        source_lineage = {}
+        model_applicability_status = "dcf_applicable"
+
+    return FakeInputs()
+
+
+def test_ronic_guardrail_flag_critical():
+    """health_terminal_ronic_guardrail_flag=True must produce critical trust state."""
+    reg = build_assumption_register(
+        "TEST", _base_inputs(),
+        diagnostics={"health_terminal_ronic_guardrail_flag": True},
+    )
+    assert reg.model_trust_state in (
+        ModelTrustState.critical_review_required.value,
+        ModelTrustState.critical_review_required,
+    )
+
+
+def test_wacc_method_spread_flags_review():
+    """wacc_method_spread_high=True must produce at least review_required trust state."""
+    reg = build_assumption_register(
+        "TEST", _base_inputs(),
+        diagnostics={"wacc_method_spread_high": True},
+    )
+    assert reg.model_trust_state not in (
+        ModelTrustState.clean.value, ModelTrustState.watch.value,
+        ModelTrustState.clean, ModelTrustState.watch,
+    )
+
+
+def test_forensic_red_flag_critical():
+    """forensic_flag_severe=True must degrade trust state to critical."""
+    reg = build_assumption_register(
+        "TEST", _base_inputs(),
+        diagnostics={"forensic_flag_severe": True},
+    )
+    assert reg.model_trust_state in (
+        ModelTrustState.critical_review_required.value,
+        ModelTrustState.critical_review_required,
+    )
+
+
+def test_regime_label_in_register_notes():
+    """regime_weights_applied=True must store regime label in register.notes dict."""
+    reg = build_assumption_register(
+        "TEST", _base_inputs(),
+        diagnostics={"regime_label": "Risk-Off", "regime_weights_applied": True},
+    )
+    assert "regime_label" in reg.notes
+    assert reg.notes["regime_label"] == "Risk-Off"

--- a/tests/test_assumption_register.py
+++ b/tests/test_assumption_register.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+import pytest
+
+from src.contracts.assumption_register import (
+    AssumptionApprovalState,
+    AssumptionEntityType,
+    AssumptionOwner,
+    AssumptionRegister,
+    AssumptionRegisterEntry,
+    AssumptionValueType,
+    FlagLevel,
+    ModelTrustState,
+)
+from src.stage_02_valuation.assumption_register import (
+    MATERIALITY_RULES,
+    build_assumption_register,
+    diff_assumption_register_entries,
+    summarize_assumption_register,
+)
+from src.stage_02_valuation.valuation_types import ForecastDrivers
+
+
+@dataclass
+class _Inputs:
+    ticker: str = "TEST"
+    drivers: ForecastDrivers | None = None
+    source_lineage: dict | None = None
+    wacc_inputs: dict | None = None
+
+
+def _drivers(**overrides) -> ForecastDrivers:
+    base = dict(
+        revenue_base=800_000_000.0,
+        revenue_growth_near=0.08,
+        revenue_growth_mid=0.05,
+        revenue_growth_terminal=0.025,
+        ebit_margin_start=0.18,
+        ebit_margin_target=0.22,
+        tax_rate_start=0.21,
+        tax_rate_target=0.23,
+        capex_pct_start=0.05,
+        capex_pct_target=0.045,
+        da_pct_start=0.03,
+        da_pct_target=0.028,
+        dso_start=45.0,
+        dso_target=43.0,
+        dio_start=35.0,
+        dio_target=33.0,
+        dpo_start=30.0,
+        dpo_target=32.0,
+        wacc=0.09,
+        exit_multiple=12.0,
+        exit_metric="ev_ebitda",
+        net_debt=100_000_000.0,
+        shares_outstanding=50_000_000.0,
+        invested_capital_start=500_000_000.0,
+        ronic_terminal=0.12,
+        terminal_blend_gordon_weight=0.60,
+        terminal_blend_exit_weight=0.40,
+        cost_of_equity=0.11,
+        debt_weight=0.20,
+    )
+    base.update(overrides)
+    return ForecastDrivers(**base)
+
+
+def _inputs(**driver_overrides) -> _Inputs:
+    wacc_input_overrides = {}
+    for key in (
+        "wacc",
+        "cost_of_equity",
+        "risk_free_rate",
+        "equity_risk_premium",
+        "beta_relevered",
+        "beta_unlevered_median",
+        "size_premium",
+        "cost_of_debt",
+        "equity_weight",
+        "debt_weight",
+    ):
+        if key in driver_overrides:
+            wacc_input_overrides[key] = driver_overrides[key]
+    return _Inputs(
+        drivers=_drivers(**driver_overrides),
+        source_lineage={
+            "revenue_growth_near": "ciq_consensus",
+            "ebit_margin_start": "ciq_snapshot",
+            "tax_rate_start": "company_etr",
+            "exit_multiple": "ciq_comps",
+            "wacc": "yfinance_capm",
+            "cost_of_equity": "yfinance_capm",
+            "debt_weight": "yfinance_capm",
+            "risk_free_rate": "config_default:0.0450",
+        },
+        wacc_inputs={
+            "wacc": 0.09,
+            "cost_of_equity": 0.11,
+            "risk_free_rate": 0.045,
+            "equity_risk_premium": 0.05,
+            "beta_relevered": 1.05,
+            "beta_unlevered_median": 0.85,
+            "size_premium": 0.01,
+            "cost_of_debt": 0.04,
+            "equity_weight": 0.80,
+            "debt_weight": 0.20,
+            "selected_methodology": {"mode": "single_method", "selected_method": "peer_bottom_up"},
+            **wacc_input_overrides,
+        },
+    )
+
+
+def test_contract_round_trips_json_and_forbids_unknown_fields():
+    entry = AssumptionRegisterEntry(
+        entity_type=AssumptionEntityType.ticker,
+        entity_id="IBM",
+        ticker="IBM",
+        assumption_name="revenue_growth_near",
+        scope="growth",
+        stage="input_assembly",
+        value_type=AssumptionValueType.numeric,
+        current_value=0.08,
+        accepted_low=0.0,
+        accepted_high=0.20,
+        range_rule_id="growth_default",
+        range_rule_description="Default PM review range for revenue growth.",
+        source_lineage={"source": "ciq_consensus"},
+        affected_forecast_lines=["revenue", "fcff", "enterprise_value", "equity_value"],
+        flag_level=FlagLevel.none,
+        owner=AssumptionOwner.deterministic,
+        approval_state=AssumptionApprovalState.none,
+    )
+    register = AssumptionRegister(ticker="IBM", entries=[entry])
+
+    restored = AssumptionRegister.model_validate_json(register.model_dump_json())
+
+    assert restored == register
+    assert restored.flag_counts["none"] == 1
+    with pytest.raises(Exception):
+        AssumptionRegisterEntry.model_validate({**entry.model_dump(mode="json"), "surprise": True})
+
+
+def test_builder_creates_numeric_effective_ticker_entries_for_dcf_wacc_and_terminal_drivers():
+    register = build_assumption_register("test", _inputs())
+    by_name = {entry.assumption_name: entry for entry in register.entries}
+
+    assert AssumptionRegister.model_validate(register.model_dump()) == register
+    assert all(entry.entity_type == AssumptionEntityType.ticker for entry in register.entries)
+    assert all(entry.value_type == AssumptionValueType.numeric for entry in register.entries)
+    assert "revenue_growth_near" in by_name
+    assert "wacc" in by_name
+    assert "risk_free_rate" in by_name
+    assert "beta_relevered" in by_name
+    assert "cost_of_debt" in by_name
+    assert "terminal_blend_gordon_weight" in by_name
+    assert "terminal_blend_exit_weight" in by_name
+    assert "tv_blended" not in by_name
+    assert by_name["wacc"].notes["selected_methodology"]["selected_method"] == "peer_bottom_up"
+
+
+def test_builder_flags_out_of_range_without_blocking_register_generation():
+    register = build_assumption_register("TEST", _inputs(revenue_growth_near=0.45))
+    growth = next(entry for entry in register.entries if entry.assumption_name == "revenue_growth_near")
+
+    assert growth.out_of_range is True
+    assert growth.flag_level == FlagLevel.review_required
+    assert register.model_trust_state == ModelTrustState.review_required
+
+
+def test_model_trust_rolls_up_critical_diagnostics():
+    register = build_assumption_register(
+        "TEST",
+        _inputs(),
+        diagnostics={"health_terminal_denominator_guardrail_flag": True},
+    )
+
+    assert register.max_flag_level == FlagLevel.critical
+    assert register.model_trust_state == ModelTrustState.critical_review_required
+
+
+def test_summary_is_compact_and_includes_flagged_entries_only():
+    register = build_assumption_register("TEST", _inputs(exit_multiple=55.0))
+
+    summary = summarize_assumption_register(register)
+
+    assert summary["model_trust_state"] == "review_required"
+    assert summary["flag_counts"]["review_required"] >= 1
+    assert all(entry["flag_level"] != "none" for entry in summary["flagged_entries"])
+    assert any(entry["assumption_name"] == "exit_multiple" for entry in summary["flagged_entries"])
+    assert len(summary["flagged_entries"]) < len(register.entries)
+
+
+def test_material_diff_ignores_tiny_changes_and_logs_material_changes():
+    previous = build_assumption_register("TEST", _inputs())
+    tiny = build_assumption_register("TEST", _inputs(wacc=0.091))
+    material = build_assumption_register("TEST", _inputs(wacc=0.096))
+
+    assert MATERIALITY_RULES["wacc"]["threshold"] == pytest.approx(0.0025)
+    assert not [
+        diff for diff in diff_assumption_register_entries(previous, tiny)
+        if diff.assumption_name == "wacc" and diff.event_type == "value_changed"
+    ]
+    assert any(
+        diff.assumption_name == "wacc" and diff.event_type == "value_changed"
+        for diff in diff_assumption_register_entries(previous, material)
+    )
+
+
+def test_material_diff_logs_flag_and_approval_changes_with_concise_payloads():
+    previous = build_assumption_register("TEST", _inputs())
+    current = build_assumption_register("TEST", _inputs(revenue_growth_near=0.45))
+
+    diffs = diff_assumption_register_entries(previous, current)
+    growth_diff = next(diff for diff in diffs if diff.assumption_name == "revenue_growth_near")
+    payload = growth_diff.model_dump(mode="json")
+
+    assert growth_diff.event_type in {"value_changed", "flag_changed"}
+    assert "flag_level" in growth_diff.changed_fields
+    assert "prior_entry" not in json.dumps(payload)
+    assert "current_entry" not in json.dumps(payload)
+
+
+def test_material_diff_surfaces_stale_pm_approval_after_value_change():
+    previous = build_assumption_register("TEST", _inputs(wacc=0.09))
+    current = build_assumption_register("TEST", _inputs(wacc=0.096))
+    previous_payload = previous.model_dump(mode="json")
+    current_payload = current.model_dump(mode="json")
+    for payload in (previous_payload, current_payload):
+        for entry in payload["entries"]:
+            if entry["assumption_name"] == "wacc":
+                entry["owner"] = "pm_override"
+                entry["approval_state"] = "pm_approved"
+                entry["approval_ref"] = "valuation_override_audit:123"
+
+    diffs = diff_assumption_register_entries(previous_payload, current_payload)
+    wacc = next(diff for diff in diffs if diff.assumption_name == "wacc")
+
+    assert wacc.changed_fields["approval_state"]["prior"] == "pm_approved"
+    assert wacc.changed_fields["approval_state"]["new"] == "stale_approval"
+    assert wacc.reason == "approval_state_changed"
+
+
+def test_assumption_register_audit_schema_and_loader_store_concise_rows():
+    import sqlite3
+
+    from db.loader import insert_assumption_register_audit, load_assumption_register_audit_history
+    from db.schema import create_tables
+
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    create_tables(conn)
+    columns = {
+        row["name"]
+        for row in conn.execute("PRAGMA table_info(assumption_register_audit)").fetchall()
+    }
+    assert {"prior_diff_json", "new_diff_json", "event_type", "assumption_name"} <= columns
+
+    previous = build_assumption_register("TEST", _inputs())
+    current = build_assumption_register("TEST", _inputs(wacc=0.096))
+    diff = next(
+        item for item in diff_assumption_register_entries(previous, current)
+        if item.assumption_name == "wacc"
+    )
+    insert_assumption_register_audit(conn, [diff.model_dump(mode="json")])
+
+    rows = load_assumption_register_audit_history(conn, "test")
+
+    assert len(rows) == 1
+    assert rows[0]["ticker"] == "TEST"
+    assert rows[0]["event_type"] == "value_changed"
+    assert rows[0]["prior_diff"]["current_value"] == pytest.approx(0.09)
+    assert rows[0]["new_diff"]["current_value"] == pytest.approx(0.096)
+    assert "entries" not in rows[0]["prior_diff_json"]

--- a/tests/test_assumption_register.py
+++ b/tests/test_assumption_register.py
@@ -353,3 +353,16 @@ def test_regime_label_in_register_notes():
     )
     assert "regime_label" in reg.notes
     assert reg.notes["regime_label"] == "Risk-Off"
+
+
+# ---------------------------------------------------------------------------
+# Task C — terminal growth range cap
+# ---------------------------------------------------------------------------
+
+def test_terminal_growth_accepted_high_capped_at_four_percent():
+    from src.stage_02_valuation.assumption_register import RANGE_RULES
+    r = RANGE_RULES.get("revenue_growth_terminal")
+    assert r is not None, "revenue_growth_terminal must have a range rule"
+    assert r["high"] <= 0.04, (
+        f"Terminal growth cap must be ≤ 4% (long-run nominal), got {r['high']}"
+    )

--- a/tests/test_batch_runner_professional.py
+++ b/tests/test_batch_runner_professional.py
@@ -152,6 +152,12 @@ def test_value_single_ticker_returns_prob_weighted_fields(monkeypatch):
     assert out["scenario_prob_bull"] == 0.2
     assert out["context_expected_iv"] == 100.0
     assert out["context_expected_upside_pct"] == 0.0
+    assert "assumption_register_json" in out
+    assumption_register = json.loads(out["assumption_register_json"])
+    assert assumption_register["model_trust_state"] in {"clean", "watch"}
+    assert any(entry["assumption_name"] == "wacc" for entry in assumption_register["entries"])
+    assert any(entry["assumption_name"] == "terminal_blend_gordon_weight" for entry in assumption_register["entries"])
+    assert json.loads(out["assumption_register_summary_json"])["flagged_entries"] == []
 
     scenario_policy = json.loads(out["context_scenario_policy_json"])
     assert scenario_policy["official_policy"] == "fixed_default"

--- a/tests/test_json_exporter.py
+++ b/tests/test_json_exporter.py
@@ -398,8 +398,10 @@ class TestBuildNestedStructure:
                     "scenarios", "scenario_policy", "context_scenarios",
                     "driver_consensus", "terminal", "health_flags", "forecast_bridge",
                     "source_lineage", "ciq_lineage", "story_profile", "story_adjustments",
-                    "drivers_raw"):
+            "drivers_raw"):
             assert key in out, f"Missing top-level key: {key}"
+        assert "assumption_register" in out
+        assert "assumption_register_summary" in out
 
     def test_ticker_uppercase(self):
         r = dict(MINIMAL_RESULT)
@@ -513,6 +515,25 @@ class TestBuildNestedStructure:
         out = build_nested_structure(r)
         assert out["drivers_raw"] == {}
         assert out["assumptions"]["growth_terminal_pct"] is None
+
+    def test_assumption_register_is_top_level_full_payload(self):
+        r = dict(MINIMAL_RESULT)
+        r["assumption_register_json"] = json.dumps({
+            "ticker": "IBM",
+            "entries": [{"assumption_name": "wacc", "current_value": 0.085, "flag_level": "none"}],
+        })
+        r["assumption_register_summary_json"] = json.dumps({
+            "model_trust_state": "clean",
+            "flag_counts": {"none": 1},
+            "max_flag_level": "none",
+            "flagged_entries": [],
+        })
+
+        out = build_nested_structure(r)
+
+        assert out["assumption_register"]["ticker"] == "IBM"
+        assert out["assumption_register"]["entries"][0]["assumption_name"] == "wacc"
+        assert out["assumption_register_summary"]["model_trust_state"] == "clean"
 
 
 # ── Tests: export_ticker_json ─────────────────────────────────────────────────

--- a/tests/test_override_workbench.py
+++ b/tests/test_override_workbench.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sqlite3
+import tempfile
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -74,7 +75,8 @@ def _temp_conn_factory(db_path: Path):
     return _factory
 
 
-def test_build_override_workbench_includes_default_effective_and_agent_values(monkeypatch, tmp_path):
+def test_build_override_workbench_includes_default_effective_and_agent_values(monkeypatch):
+    tmp_path = Path(tempfile.mkdtemp())
     from src.stage_04_pipeline.override_workbench import build_override_workbench
 
     baseline = _inputs(
@@ -192,7 +194,8 @@ def test_preview_override_selections_resolves_agent_and_custom(monkeypatch):
     assert preview["proposed_iv"]["base"] > preview["current_iv"]["base"]
 
 
-def test_apply_override_selections_updates_yaml_and_writes_sql_audit(monkeypatch, tmp_path):
+def test_apply_override_selections_updates_yaml_and_writes_sql_audit(monkeypatch):
+    tmp_path = Path(tempfile.mkdtemp())
     from src.stage_04_pipeline.override_workbench import apply_override_selections, load_override_audit_history
 
     baseline = _inputs(
@@ -263,7 +266,8 @@ def test_apply_override_selections_updates_yaml_and_writes_sql_audit(monkeypatch
     assert all(row["proposed_iv_base"] is not None for row in history)
 
 
-def test_load_assumption_register_audit_history_is_separate_from_override_history(monkeypatch, tmp_path):
+def test_load_assumption_register_audit_history_is_separate_from_override_history(monkeypatch):
+    tmp_path = Path(tempfile.mkdtemp())
     from db.loader import insert_assumption_register_audit
     from src.stage_04_pipeline.override_workbench import load_assumption_register_audit_history
 

--- a/tests/test_override_workbench.py
+++ b/tests/test_override_workbench.py
@@ -136,6 +136,8 @@ def test_build_override_workbench_includes_default_effective_and_agent_values(mo
     assert row["agent_value"] == pytest.approx(0.12)
     assert row["effective_source"] == "override_ticker"
     assert row["initial_mode"] == "custom"
+    assert workbench["assumption_register"]["ticker"] == "IBM"
+    assert workbench["assumption_register_summary"]["model_trust_state"] in {"clean", "watch"}
 
 
 def test_preview_override_selections_resolves_agent_and_custom(monkeypatch):
@@ -259,3 +261,38 @@ def test_apply_override_selections_updates_yaml_and_writes_sql_audit(monkeypatch
     assert fields == {"revenue_growth_near", "ebit_margin_start"}
     assert all(row["actor"] == "dashboard" for row in history)
     assert all(row["proposed_iv_base"] is not None for row in history)
+
+
+def test_load_assumption_register_audit_history_is_separate_from_override_history(monkeypatch, tmp_path):
+    from db.loader import insert_assumption_register_audit
+    from src.stage_04_pipeline.override_workbench import load_assumption_register_audit_history
+
+    db_path = tmp_path / "audit.db"
+    conn = _temp_conn_factory(db_path)()
+    insert_assumption_register_audit(
+        conn,
+        [
+            {
+                "event_ts": "2026-05-11T00:00:00+00:00",
+                "actor": "system",
+                "actor_type": "system",
+                "entity_type": "ticker",
+                "entity_id": "IBM",
+                "ticker": "IBM",
+                "assumption_name": "wacc",
+                "scope": "wacc",
+                "event_type": "value_changed",
+                "changed_fields": {"current_value": {"prior": 0.09, "new": 0.095}},
+                "valuation_impact": None,
+                "reason": None,
+            }
+        ],
+    )
+    conn.close()
+    monkeypatch.setattr("src.stage_04_pipeline.override_workbench.get_connection", _temp_conn_factory(db_path))
+
+    history = load_assumption_register_audit_history("ibm")
+
+    assert len(history) == 1
+    assert history[0]["assumption_name"] == "wacc"
+    assert history[0]["prior_diff"]["current_value"] == pytest.approx(0.09)

--- a/tests/test_peer_universe_contract.py
+++ b/tests/test_peer_universe_contract.py
@@ -1,0 +1,107 @@
+import pytest
+from src.contracts.peer_universe import PeerCandidate, PeerUniverse, InclusionState
+
+
+def test_peer_candidate_core_when_both_sector_and_industry_match():
+    """Both sector + industry match → sector_score=1.0 → should reach core threshold."""
+    c = PeerCandidate(
+        target_ticker="AAPL",
+        peer_ticker="MSFT",
+        sources=["ciq"],
+        sector_match=True,
+        industry_match=True,
+        business_description_similarity=0.80,
+        metric_similarity=0.72,
+        size_similarity=0.65,
+        growth_similarity=0.60,
+        margin_similarity=0.70,
+        capital_intensity_similarity=0.55,
+    )
+    # composite = 0.80*0.35 + 0.72*0.35 + 1.0*0.15 + 0.65*0.15 = 0.28+0.252+0.15+0.0975 = 0.7795
+    assert c.composite_score == pytest.approx(0.7795, abs=0.01)
+    assert c.inclusion_state == InclusionState.core
+
+
+def test_peer_candidate_peripheral_when_sector_only():
+    """sector_match only (no industry) → sector_score=0.6 → peripheral range."""
+    c = PeerCandidate(
+        target_ticker="AAPL",
+        peer_ticker="GOOG",
+        sources=["ciq"],
+        sector_match=True,
+        industry_match=False,
+        business_description_similarity=0.70,
+        metric_similarity=0.65,
+        size_similarity=0.60,
+        growth_similarity=0.55,
+        margin_similarity=0.60,
+        capital_intensity_similarity=0.50,
+    )
+    # composite = 0.70*0.35 + 0.65*0.35 + 0.6*0.15 + 0.60*0.15 = 0.245+0.2275+0.09+0.09 = 0.6525
+    assert c.composite_score == pytest.approx(0.6525, abs=0.01)
+    assert c.inclusion_state == InclusionState.peripheral
+
+
+def test_peer_candidate_excluded_below_threshold():
+    c = PeerCandidate(
+        target_ticker="X", peer_ticker="Y", sources=["test"],
+        sector_match=False, industry_match=False,
+        business_description_similarity=0.30, metric_similarity=0.30,
+        size_similarity=0.30, growth_similarity=0.30,
+        margin_similarity=0.30, capital_intensity_similarity=0.30,
+    )
+    assert c.inclusion_state == InclusionState.excluded
+
+
+def test_peer_universe_core_peers_list():
+    c = PeerCandidate(
+        target_ticker="AAPL", peer_ticker="MSFT", sources=["ciq"],
+        sector_match=True, industry_match=True,
+        business_description_similarity=0.90, metric_similarity=0.85,
+        size_similarity=0.80, growth_similarity=0.75,
+        margin_similarity=0.80, capital_intensity_similarity=0.70,
+    )
+    u = PeerUniverse(target_ticker="AAPL", candidates=[c])
+    assert "MSFT" in u.core_peers
+    assert u.peripheral_peers == []
+
+
+def test_peer_universe_round_trip():
+    c = PeerCandidate(
+        target_ticker="AAPL", peer_ticker="MSFT", sources=["ciq"],
+        sector_match=True, industry_match=True,
+        business_description_similarity=0.9, metric_similarity=0.8,
+        size_similarity=0.7, growth_similarity=0.7,
+        margin_similarity=0.8, capital_intensity_similarity=0.6,
+    )
+    u = PeerUniverse(target_ticker="AAPL", candidates=[c])
+    dumped = u.model_dump(mode="json")
+    restored = PeerUniverse.model_validate(dumped)
+    assert restored.target_ticker == "AAPL"
+    assert restored.core_peers == ["MSFT"]
+
+
+def test_pm_override_promotes_excluded_peer():
+    c = PeerCandidate(
+        target_ticker="X", peer_ticker="Y", sources=["pm"],
+        sector_match=False, industry_match=False,
+        business_description_similarity=0.20, metric_similarity=0.20,
+        size_similarity=0.20, growth_similarity=0.20,
+        margin_similarity=0.20, capital_intensity_similarity=0.20,
+        pm_override_state="included",
+        pm_override_reason="Closest proxy available",
+    )
+    assert c.inclusion_state == InclusionState.excluded    # raw score still low
+    assert c.effective_inclusion == InclusionState.core    # PM override wins
+
+
+def test_tickers_uppercased():
+    c = PeerCandidate(
+        target_ticker="aapl", peer_ticker="msft", sources=[],
+        sector_match=True, industry_match=True,
+        business_description_similarity=0.8, metric_similarity=0.8,
+        size_similarity=0.8, growth_similarity=0.8,
+        margin_similarity=0.8, capital_intensity_similarity=0.8,
+    )
+    assert c.target_ticker == "AAPL"
+    assert c.peer_ticker == "MSFT"

--- a/tests/test_ticker_dossier_contract_runtime.py
+++ b/tests/test_ticker_dossier_contract_runtime.py
@@ -18,6 +18,12 @@ def _legacy_payload() -> dict:
         "scenarios": {"base": {"probability": 0.6, "iv": 202.0}},
         "terminal": {},
         "health_flags": {},
+        "assumption_register_summary": {
+            "model_trust_state": "review_required",
+            "flag_counts": {"none": 2, "watch": 0, "review_required": 1, "critical": 0},
+            "max_flag_level": "review_required",
+            "flagged_entries": [{"assumption_name": "wacc", "flag_level": "review_required"}],
+        },
         "forecast_bridge": [{"year": 2027, "fcff_mm": 100.0}],
         "source_lineage": {"wacc": "override"},
         "ciq_lineage": {"snapshot_source_file": "IBM_comps.xlsx", "snapshot_as_of_date": "2026-03-01", "peer_count": 4},
@@ -61,6 +67,7 @@ def test_ticker_dossier_model_validates_required_envelope_and_round_trips_json()
         "api_view",
         "react_view",
         "excel_view",
+        "assumption_register_summary",
         "forecast_bridge",
         "html_view",
         "debug_view",
@@ -150,5 +157,7 @@ def test_legacy_workspace_and_summary_payloads_can_be_derived_from_dossier():
     assert workspace["ticker"] == "IBM"
     assert workspace["base_iv"] == 202.0
     assert workspace["ticker_dossier_contract_version"] == "1.0.0"
+    assert workspace["assumption_register_summary"]["model_trust_state"] == "review_required"
     assert summary["weighted_iv"] == 205.0
+    assert summary["assumption_register_summary"]["flagged_entries"][0]["assumption_name"] == "wacc"
     assert summary["why_it_matters"] == "Base IV $202.00 versus current price $260.00."

--- a/tests/test_valuation_input_assembler.py
+++ b/tests/test_valuation_input_assembler.py
@@ -21,6 +21,21 @@ def test_financials_and_reits_marked_alt_model_required():
     assert determine_model_applicability("Technology", "Software") == "dcf_applicable"
 
 
+def test_apply_overrides_prefers_approved_assumption_register(monkeypatch):
+    from src.stage_02_valuation import input_assembler as ia
+    from src.stage_04_pipeline import pending_assumption_changes
+
+    drivers = SimpleNamespace(ebit_margin_start=0.18)
+    source_lineage = {"ebit_margin_start": "ciq"}
+    monkeypatch.setattr(ia, "load_valuation_overrides", lambda: {"global": {}, "sectors": {}, "tickers": {"IBM": {"ebit_margin_start": 0.19}}})
+    monkeypatch.setattr(pending_assumption_changes, "approved_assumption_overrides_for_ticker", lambda ticker: {"ebit_margin_start": 0.21})
+
+    ia._apply_overrides(drivers, source_lineage, ticker="IBM", sector="Technology")
+
+    assert drivers.ebit_margin_start == pytest.approx(0.21)
+    assert source_lineage["ebit_margin_start"] == "approved_assumption_register"
+
+
 def test_build_valuation_inputs_applies_ciq_precedence(monkeypatch):
     from src.stage_02_valuation import input_assembler as ia
 

--- a/tests/test_valuation_input_assembler.py
+++ b/tests/test_valuation_input_assembler.py
@@ -22,13 +22,13 @@ def test_financials_and_reits_marked_alt_model_required():
 
 
 def test_apply_overrides_prefers_approved_assumption_register(monkeypatch):
+    import db.loader as db_loader
     from src.stage_02_valuation import input_assembler as ia
-    from src.stage_04_pipeline import pending_assumption_changes
 
     drivers = SimpleNamespace(ebit_margin_start=0.18)
     source_lineage = {"ebit_margin_start": "ciq"}
     monkeypatch.setattr(ia, "load_valuation_overrides", lambda: {"global": {}, "sectors": {}, "tickers": {"IBM": {"ebit_margin_start": 0.19}}})
-    monkeypatch.setattr(pending_assumption_changes, "approved_assumption_overrides_for_ticker", lambda ticker: {"ebit_margin_start": 0.21})
+    monkeypatch.setattr(db_loader, "get_approved_assumption_overrides", lambda ticker: {"ebit_margin_start": 0.21})
 
     ia._apply_overrides(drivers, source_lineage, ticker="IBM", sector="Technology")
 


### PR DESCRIPTION
## Summary

Closes the actionable P0 items from the valuation methodology critical review (`docs/design-docs/valuation-methodology-critical-review-and-action-plan.md`).

- **PeerUniverse contract** (`src/contracts/peer_universe.py`) — `PeerCandidate` with composite scoring (biz 35%, metric 35%, sector 15%, size 15%), `InclusionState` (core/peripheral/excluded), PM override promotion, `PeerUniverse` with computed `core_peers`/`peripheral_peers`. Foundational for TD-03 replacement.
- **Diagnostic rollup extension** — four new wires into the assumption register trust state:
  - `health_terminal_ronic_guardrail_flag` → **CRITICAL** (was already computed, just not escalated)
  - `forensic_flag_severe` (M-Score red zone) → **CRITICAL**
  - `wacc_method_spread_high` (≥150bps spread across methods) → **REVIEW_REQUIRED** — computed in `wacc.py`, threaded through `input_assembler`, surfaced in `batch_runner` diagnostics
  - Regime label stored in `register.notes` when `regime_weights_applied=True`
- **Terminal growth cap** — `RANGE_RULES["revenue_growth_terminal"]["high"]` tightened from 0.05 → 0.04 (long-run nominal GDP cap), pinned with a test

## V2 issues logged
#61 #62 #63 #64 #65

## Test plan

- [ ] `python -m pytest tests/test_assumption_register.py tests/test_peer_universe_contract.py tests/test_assumption_policy.py tests/test_api_contracts.py tests/test_batch_runner_professional.py tests/test_json_exporter.py tests/test_override_workbench.py tests/test_recommendations.py tests/test_ticker_dossier_contract_runtime.py tests/test_valuation_input_assembler.py -q` → 135 passed, 0 errors
- [ ] `npm --prefix frontend run build` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)