### PR TITLE
Add PM approve/reject/defer transitions and post-approval apply

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -72,6 +72,10 @@ class PendingAssumptionApplyRequest(BaseModel):
     change_ids: list[int] = Field(default_factory=list)
 
 
+class PendingAssumptionDecisionRequest(BaseModel):
+    change_ids: list[int] = Field(default_factory=list)
+
+
 class AnalysisRunRequest(BaseModel):
     use_cache: bool = True
     force_refresh_agents: list[str] = Field(default_factory=list)
@@ -418,6 +422,24 @@ def apply_pending_assumptions_payload(
     return apply_pending_assumption_stack(ticker, change_ids, actor=actor)
 
 
+def approve_pending_assumptions_payload(ticker: str, change_ids: list[int], actor: str = "api") -> dict[str, Any]:
+    from src.stage_04_pipeline.pending_assumption_changes import approve_pending_assumption_changes
+
+    return approve_pending_assumption_changes(ticker, change_ids, actor=actor)
+
+
+def reject_pending_assumptions_payload(ticker: str, change_ids: list[int], actor: str = "api") -> dict[str, Any]:
+    from src.stage_04_pipeline.pending_assumption_changes import reject_pending_assumption_changes
+
+    return reject_pending_assumption_changes(ticker, change_ids, actor=actor)
+
+
+def defer_pending_assumptions_payload(ticker: str, change_ids: list[int], actor: str = "api") -> dict[str, Any]:
+    from src.stage_04_pipeline.pending_assumption_changes import defer_pending_assumption_changes
+
+    return defer_pending_assumption_changes(ticker, change_ids, actor=actor)
+
+
 build_ticker_overview_payload = build_overview_payload
 
 
@@ -691,6 +713,49 @@ def create_app() -> FastAPI:
             request_payload.change_ids,
             manual_values=request_payload.manual_values,
         )
+
+
+    @app.post("/api/tickers/{ticker}/valuation/pending-changes/approve", status_code=202)
+    def approve_ticker_pending_assumption_changes(
+        ticker: str,
+        payload: PendingAssumptionDecisionRequest | None = None,
+    ) -> dict[str, Any]:
+        ticker = api_coerce_ticker(ticker)
+        request_payload = payload or PendingAssumptionDecisionRequest()
+
+        def _runner(_run_id: str) -> dict[str, Any]:
+            return approve_pending_assumptions_payload(ticker, request_payload.change_ids, actor="api")
+
+        run_id = submit_background_run("valuation_pending_changes_approve", _runner, ticker=ticker)
+        return {"run_id": run_id, "status": "queued"}
+
+    @app.post("/api/tickers/{ticker}/valuation/pending-changes/reject", status_code=202)
+    def reject_ticker_pending_assumption_changes(
+        ticker: str,
+        payload: PendingAssumptionDecisionRequest | None = None,
+    ) -> dict[str, Any]:
+        ticker = api_coerce_ticker(ticker)
+        request_payload = payload or PendingAssumptionDecisionRequest()
+
+        def _runner(_run_id: str) -> dict[str, Any]:
+            return reject_pending_assumptions_payload(ticker, request_payload.change_ids, actor="api")
+
+        run_id = submit_background_run("valuation_pending_changes_reject", _runner, ticker=ticker)
+        return {"run_id": run_id, "status": "queued"}
+
+    @app.post("/api/tickers/{ticker}/valuation/pending-changes/defer", status_code=202)
+    def defer_ticker_pending_assumption_changes(
+        ticker: str,
+        payload: PendingAssumptionDecisionRequest | None = None,
+    ) -> dict[str, Any]:
+        ticker = api_coerce_ticker(ticker)
+        request_payload = payload or PendingAssumptionDecisionRequest()
+
+        def _runner(_run_id: str) -> dict[str, Any]:
+            return defer_pending_assumptions_payload(ticker, request_payload.change_ids, actor="api")
+
+        run_id = submit_background_run("valuation_pending_changes_defer", _runner, ticker=ticker)
+        return {"run_id": run_id, "status": "queued"}
 
     @app.post("/api/tickers/{ticker}/valuation/pending-changes/apply", status_code=202)
     def apply_ticker_pending_assumption_changes(

--- a/db/loader.py
+++ b/db/loader.py
@@ -817,7 +817,7 @@ def load_pending_assumption_changes(
     return out
 
 
-def apply_pending_assumption_changes(
+def approve_pending_assumption_changes(
     conn: sqlite3.Connection,
     *,
     ticker: str,
@@ -826,7 +826,7 @@ def apply_pending_assumption_changes(
     applied_at: str,
     approval_ref: str,
 ) -> list[dict[str, Any]]:
-    """Approve selected pending changes and make them active effective entries."""
+    """Mark selected pending changes as approved without mutating active assumptions."""
     if not change_ids:
         return []
     ticker = str(ticker).upper()
@@ -836,6 +836,48 @@ def apply_pending_assumption_changes(
         SELECT id, ticker, assumption_name, proposed_value, source_type, source_ref, metadata_json
         FROM pending_assumption_changes
         WHERE ticker = ? AND status = 'pending' AND id IN ({placeholders})
+        ORDER BY id
+        """,
+        [ticker, *change_ids],
+    ).fetchall()
+    approved = [dict(row) for row in rows]
+    if not approved:
+        return []
+    with conn:
+        for row in approved:
+            conn.execute(
+                """
+                UPDATE pending_assumption_changes
+                SET status = 'approved', updated_at = ?, applied_at = ?, approval_ref = ?
+                WHERE id = ?
+                """,
+                [applied_at, applied_at, approval_ref, row["id"]],
+            )
+    for row in approved:
+        row["metadata"] = json.loads(row.pop("metadata_json") or "{}")
+        row["change_id"] = row.pop("id")
+        row["approval_ref"] = approval_ref
+        row["applied_at"] = applied_at
+    return approved
+
+
+def apply_approved_assumption_changes(
+    conn: sqlite3.Connection,
+    *,
+    ticker: str,
+    change_ids: list[int],
+    actor: str,
+    applied_at: str,
+) -> list[dict[str, Any]]:
+    if not change_ids:
+        return []
+    ticker = str(ticker).upper()
+    placeholders = ",".join("?" for _ in change_ids)
+    rows = conn.execute(
+        f"""
+        SELECT id, ticker, assumption_name, proposed_value, source_type, source_ref, metadata_json, approval_ref
+        FROM pending_assumption_changes
+        WHERE ticker = ? AND status = 'approved' AND id IN ({placeholders})
         ORDER BY id
         """,
         [ticker, *change_ids],
@@ -867,23 +909,14 @@ def apply_pending_assumption_changes(
                     row["proposed_value"],
                     row["source_type"],
                     row["source_ref"],
-                    approval_ref,
+                    row.get("approval_ref"),
                     actor,
                     row["metadata_json"] or "{}",
                 ],
             )
-            conn.execute(
-                """
-                UPDATE pending_assumption_changes
-                SET status = 'approved', updated_at = ?, applied_at = ?, approval_ref = ?
-                WHERE id = ?
-                """,
-                [applied_at, applied_at, approval_ref, row["id"]],
-            )
     for row in approved:
         row["metadata"] = json.loads(row.pop("metadata_json") or "{}")
         row["change_id"] = row.pop("id")
-        row["approval_ref"] = approval_ref
         row["applied_at"] = applied_at
     return approved
 
@@ -906,6 +939,28 @@ def reject_pending_assumption_changes(
         WHERE ticker = ? AND status = 'pending' AND id IN ({placeholders})
         """,
         [rejected_at, str(ticker).upper(), *change_ids],
+    )
+    conn.commit()
+    return int(cursor.rowcount or 0)
+
+
+def defer_pending_assumption_changes(
+    conn: sqlite3.Connection,
+    *,
+    ticker: str,
+    change_ids: list[int],
+    deferred_at: str,
+) -> int:
+    if not change_ids:
+        return 0
+    placeholders = ",".join("?" for _ in change_ids)
+    cursor = conn.execute(
+        f"""
+        UPDATE pending_assumption_changes
+        SET status = 'deferred', updated_at = ?
+        WHERE ticker = ? AND status = 'pending' AND id IN ({placeholders})
+        """,
+        [deferred_at, str(ticker).upper(), *change_ids],
     )
     conn.commit()
     return int(cursor.rowcount or 0)

--- a/src/contracts/assumption_policy.py
+++ b/src/contracts/assumption_policy.py
@@ -18,6 +18,7 @@ class PendingAssumptionStatus(str, Enum):
     pending = "pending"
     approved = "approved"
     rejected = "rejected"
+    deferred = "deferred"
     superseded = "superseded"
 
 

--- a/src/stage_04_pipeline/pending_assumption_changes.py
+++ b/src/stage_04_pipeline/pending_assumption_changes.py
@@ -157,18 +157,16 @@ def apply_pending_assumption_stack(
     actor: str = "api",
 ) -> dict[str, Any]:
     applied_at = _now()
-    approval_ref = f"assumption_register_apply:{ticker.upper()}:{applied_at}"
     with get_connection() as conn:
         create_tables(conn)
-        from db.loader import apply_pending_assumption_changes, insert_assumption_register_audit
+        from db.loader import apply_approved_assumption_changes, insert_assumption_register_audit
 
-        approved = apply_pending_assumption_changes(
+        approved = apply_approved_assumption_changes(
             conn,
             ticker=ticker,
             change_ids=change_ids,
             actor=actor,
             applied_at=applied_at,
-            approval_ref=approval_ref,
         )
         audit_rows = []
         for row in approved:
@@ -193,9 +191,74 @@ def apply_pending_assumption_stack(
         "ticker": ticker.upper(),
         "applied_count": len(approved),
         "change_ids": [row["change_id"] for row in approved],
-        "approval_ref": approval_ref,
         "actor": actor,
     }
+
+
+def approve_pending_assumption_changes(ticker: str, change_ids: list[int], *, actor: str = "api") -> dict[str, Any]:
+    approved_at = _now()
+    approval_ref = f"assumption_register_approval:{ticker.upper()}:{approved_at}"
+    with get_connection() as conn:
+        create_tables(conn)
+        from db.loader import approve_pending_assumption_changes, insert_assumption_register_audit
+
+        approved = approve_pending_assumption_changes(
+            conn,
+            ticker=ticker,
+            change_ids=change_ids,
+            actor=actor,
+            applied_at=approved_at,
+            approval_ref=approval_ref,
+        )
+        insert_assumption_register_audit(
+            conn,
+            [
+                {
+                    "event_ts": approved_at,
+                    "actor": actor,
+                    "actor_type": "pm" if actor != "system" else "system",
+                    "entity_type": "ticker",
+                    "entity_id": ticker.upper(),
+                    "ticker": ticker.upper(),
+                    "assumption_name": row["assumption_name"],
+                    "scope": "dcf",
+                    "event_type": "pm_override_approved",
+                    "changed_fields": {"status": {"prior": "pending", "new": "approved"}},
+                    "valuation_impact": None,
+                    "reason": row.get("source_ref"),
+                }
+                for row in approved
+            ],
+        )
+    return {"ticker": ticker.upper(), "approved_count": len(approved), "change_ids": [r["change_id"] for r in approved]}
+
+
+def reject_pending_assumption_changes(ticker: str, change_ids: list[int], *, actor: str = "api") -> dict[str, Any]:
+    changed_at = _now()
+    with get_connection() as conn:
+        create_tables(conn)
+        from db.loader import insert_assumption_register_audit, reject_pending_assumption_changes
+
+        count = reject_pending_assumption_changes(conn, ticker=ticker, change_ids=change_ids, actor=actor, rejected_at=changed_at)
+        insert_assumption_register_audit(
+            conn,
+            [{"event_ts": changed_at, "actor": actor, "actor_type": "pm", "entity_type": "ticker", "entity_id": ticker.upper(), "ticker": ticker.upper(), "assumption_name": "*", "scope": "dcf", "event_type": "pm_override_rejected", "changed_fields": {"status": {"prior": "pending", "new": "rejected"}}, "valuation_impact": None, "reason": f"change_ids={change_ids}"}],
+        )
+    return {"ticker": ticker.upper(), "rejected_count": count, "change_ids": change_ids}
+
+
+def defer_pending_assumption_changes(ticker: str, change_ids: list[int], *, actor: str = "api") -> dict[str, Any]:
+    changed_at = _now()
+    with get_connection() as conn:
+        create_tables(conn)
+        from db.loader import defer_pending_assumption_changes, insert_assumption_register_audit
+
+        count = defer_pending_assumption_changes(conn, ticker=ticker, change_ids=change_ids, deferred_at=changed_at)
+        insert_assumption_register_audit(
+            conn,
+            [{"event_ts": changed_at, "actor": actor, "actor_type": "pm", "entity_type": "ticker", "entity_id": ticker.upper(), "ticker": ticker.upper(), "assumption_name": "*", "scope": "dcf", "event_type": "pm_override_deferred", "changed_fields": {"status": {"prior": "pending", "new": "deferred"}}, "valuation_impact": None, "reason": f"change_ids={change_ids}"}],
+        )
+    return {"ticker": ticker.upper(), "deferred_count": count, "change_ids": change_ids}
 
 
 def approved_assumption_overrides_for_ticker(ticker: str) -> dict[str, float]:

--- a/tests/test_assumption_policy.py
+++ b/tests/test_assumption_policy.py
@@ -74,7 +74,8 @@ def test_damodaran_drop_folder_parses_csv_drafts(tmp_path, monkeypatch):
 
 def test_pending_change_apply_creates_active_approved_entry():
     from db.loader import (
-        apply_pending_assumption_changes,
+        apply_approved_assumption_changes,
+        approve_pending_assumption_changes,
         insert_pending_assumption_change,
         load_approved_assumption_entries,
     )
@@ -103,13 +104,20 @@ def test_pending_change_apply_creates_active_approved_entry():
         },
     )
 
-    applied = apply_pending_assumption_changes(
+    approve_pending_assumption_changes(
         conn,
         ticker="IBM",
         change_ids=[change_id],
         actor="api",
         applied_at="2026-01-02T00:00:00Z",
-        approval_ref="assumption_register_apply:IBM:2026-01-02T00:00:00Z",
+        approval_ref="assumption_register_approval:IBM:2026-01-02T00:00:00Z",
+    )
+    applied = apply_approved_assumption_changes(
+        conn,
+        ticker="IBM",
+        change_ids=[change_id],
+        actor="api",
+        applied_at="2026-01-03T00:00:00Z",
     )
     active = load_approved_assumption_entries(conn, "IBM")
 


### PR DESCRIPTION
### Motivation
- Ensure PM approval is a hard gate so LLM/judgment-layer suggestions never mutate deterministic inputs until explicitly approved. 
- Preserve an immutable proposal and decision history for auditability while keeping the canonical assumption register as the single source of deterministic overrides. 
- Support non-mutating decision states (`approved`, `rejected`, `deferred`) so rejected or deferred suggestions never enter deterministic flows. 

### Description
- Add `deferred` to the `PendingAssumptionStatus` enum in `src/contracts/assumption_policy.py`. 
- Split DB workflows in `db/loader.py` into a non-mutating approval step `approve_pending_assumption_changes`, a separate deterministic write step `apply_approved_assumption_changes`, and a `defer_pending_assumption_changes` helper, while keeping `reject_pending_assumption_changes`. 
- Update stage-04 services in `src/stage_04_pipeline/pending_assumption_changes.py` to provide service-level `approve`, `reject`, and `defer` methods that record audit events and to make `apply_pending_assumption_stack` only write already-approved entries via `apply_approved_assumption_changes`. 
- Add API helpers and endpoints in `api/main.py` (`POST /api/tickers/{ticker}/valuation/pending-changes/approve`, `/reject`, `/defer`) and a `PendingAssumptionDecisionRequest` model, preserving the existing `apply` endpoint as the deterministic execution step. 
- Keep immutable audit entries for `pm_override_approved`, `pm_override_rejected`, `pm_override_deferred`, and `pm_override_applied` via `insert_assumption_register_audit`, and update tests to validate the two-step `approve` then `apply` flow. 

### Testing
- Ran the targeted unit tests with `PYTHONPATH=. pytest -q tests/test_assumption_policy.py::test_pending_change_apply_creates_active_approved_entry tests/test_api_contracts.py::test_policy_and_pending_change_endpoints`. 
- The first run without `PYTHONPATH` failed due to an import error (`ModuleNotFoundError: No module named 'db'`) caused by the test runner environment. 
- Re-running with `PYTHONPATH=.` succeeded and the two tests passed: `2 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ee6f372a0832fa139a136757e7860)