### PR TITLE
Extend pending-change API/UI with approval card fields and status actions

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -72,6 +72,10 @@ class PendingAssumptionApplyRequest(BaseModel):
     change_ids: list[int] = Field(default_factory=list)
 
 
+class PendingAssumptionTransitionRequest(BaseModel):
+    change_ids: list[int] = Field(default_factory=list)
+
+
 class AnalysisRunRequest(BaseModel):
     use_cache: bool = True
     force_refresh_agents: list[str] = Field(default_factory=list)
@@ -392,9 +396,9 @@ def parse_damodaran_policy_drafts_payload() -> dict[str, Any]:
 
 
 def list_pending_assumptions_payload(ticker: str) -> dict[str, Any]:
-    from src.stage_04_pipeline.pending_assumption_changes import list_pending_assumption_changes
+    from src.stage_04_pipeline.pending_assumption_changes import list_pending_assumption_changes_with_preview
 
-    changes = [change.model_dump() for change in list_pending_assumption_changes(ticker)]
+    changes = list_pending_assumption_changes_with_preview(ticker)
     return {"ticker": ticker.upper(), "pending_changes": changes}
 
 
@@ -704,6 +708,38 @@ def create_app() -> FastAPI:
             return apply_pending_assumptions_payload(ticker, request_payload.change_ids, actor="api")
 
         run_id = submit_background_run("valuation_pending_changes_apply", _runner, ticker=ticker)
+        return {"run_id": run_id, "status": "queued"}
+
+    @app.post("/api/tickers/{ticker}/valuation/pending-changes/reject", status_code=202)
+    def reject_ticker_pending_assumption_changes(
+        ticker: str,
+        payload: PendingAssumptionTransitionRequest | None = None,
+    ) -> dict[str, Any]:
+        ticker = api_coerce_ticker(ticker)
+        request_payload = payload or PendingAssumptionTransitionRequest()
+
+        def _runner(_run_id: str) -> dict[str, Any]:
+            from src.stage_04_pipeline.pending_assumption_changes import transition_pending_assumption_statuses
+
+            return transition_pending_assumption_statuses(ticker, request_payload.change_ids, target_status="rejected", actor="api")
+
+        run_id = submit_background_run("valuation_pending_changes_reject", _runner, ticker=ticker)
+        return {"run_id": run_id, "status": "queued"}
+
+    @app.post("/api/tickers/{ticker}/valuation/pending-changes/defer", status_code=202)
+    def defer_ticker_pending_assumption_changes(
+        ticker: str,
+        payload: PendingAssumptionTransitionRequest | None = None,
+    ) -> dict[str, Any]:
+        ticker = api_coerce_ticker(ticker)
+        request_payload = payload or PendingAssumptionTransitionRequest()
+
+        def _runner(_run_id: str) -> dict[str, Any]:
+            from src.stage_04_pipeline.pending_assumption_changes import transition_pending_assumption_statuses
+
+            return transition_pending_assumption_statuses(ticker, request_payload.change_ids, target_status="deferred", actor="api")
+
+        run_id = submit_background_run("valuation_pending_changes_defer", _runner, ticker=ticker)
         return {"run_id": run_id, "status": "queued"}
 
     @app.get("/api/tickers/{ticker}/market")

--- a/db/loader.py
+++ b/db/loader.py
@@ -911,6 +911,51 @@ def reject_pending_assumption_changes(
     return int(cursor.rowcount or 0)
 
 
+def transition_pending_assumption_changes_status(
+    conn: sqlite3.Connection,
+    *,
+    ticker: str,
+    change_ids: list[int],
+    status: str,
+    updated_at: str,
+) -> list[dict[str, Any]]:
+    if not change_ids:
+        return []
+    placeholders = ",".join("?" for _ in change_ids)
+    ticker_value = str(ticker).upper()
+    rows = conn.execute(
+        f"""
+        SELECT id, created_at, updated_at, ticker, assumption_name, current_value,
+               proposed_value, source_type, source_ref, confidence, rationale,
+               citation, status, approval_ref, applied_at, metadata_json
+        FROM pending_assumption_changes
+        WHERE ticker = ? AND status = 'pending' AND id IN ({placeholders})
+        ORDER BY id
+        """,
+        [ticker_value, *change_ids],
+    ).fetchall()
+    selected = [dict(row) for row in rows]
+    if not selected:
+        return []
+    with conn:
+        conn.execute(
+            f"""
+            UPDATE pending_assumption_changes
+            SET status = ?, updated_at = ?
+            WHERE ticker = ? AND status = 'pending' AND id IN ({placeholders})
+            """,
+            [status, updated_at, ticker_value, *change_ids],
+        )
+    out: list[dict[str, Any]] = []
+    for row in selected:
+        row["metadata"] = json.loads(row.pop("metadata_json") or "{}")
+        row["change_id"] = row.pop("id")
+        row["status"] = status
+        row["updated_at"] = updated_at
+        out.append(row)
+    return out
+
+
 def load_approved_assumption_entries(conn: sqlite3.Connection, ticker: str) -> list[dict[str, Any]]:
     rows = conn.execute(
         """

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -167,6 +167,13 @@ export function applyRecommendations(ticker: string, payload: unknown): Promise<
   });
 }
 
+export function applyPendingChangesAction(ticker: string, action: "apply" | "reject" | "defer", payload: unknown): Promise<RunPayload> {
+  return requestJSON<RunPayload>(`/tickers/${encodeURIComponent(ticker)}/valuation/pending-changes/${action}`, {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
 export function getMarket(ticker: string): Promise<MarketPayload> {
   return requestJSON<MarketPayload>(`/tickers/${encodeURIComponent(ticker)}/market`);
 }

--- a/frontend/src/pages/ValuationPage.tsx
+++ b/frontend/src/pages/ValuationPage.tsx
@@ -5,6 +5,7 @@ import { useOutletContext, useParams, useSearchParams } from "react-router-dom";
 import { PageHero } from "@/components/PageHero";
 import {
   applyRecommendations,
+  applyPendingChangesAction,
   applyValuationAssumptions,
   applyWacc,
   createTickerExport,
@@ -905,6 +906,7 @@ function AssumptionsPanel({
   previewPending,
   onPreview,
   onApply,
+  onPendingAction,
   applyPending,
   runStatus,
 }: {
@@ -924,6 +926,7 @@ function AssumptionsPanel({
   previewPending: boolean;
   onPreview: () => void;
   onApply: () => void;
+  onPendingAction: (action: "apply" | "reject" | "defer", changeId: number) => void;
   applyPending: boolean;
   runStatus: Record<string, unknown> | null | undefined;
 }) {
@@ -978,23 +981,35 @@ function AssumptionsPanel({
         {renderValueTable(
           pendingChanges.map((change) => ({
             id: change.change_id,
-            field: change.assumption_name,
-            current: change.current_value,
-            proposed: change.proposed_value,
-            source: change.source_ref,
+            proposed_change: `${String(change.assumption_name)}: ${String(change.current_value ?? "—")} → ${String(change.proposed_value ?? "—")}`,
             confidence: change.confidence,
+            why: Array.isArray(change.rationale_bullets) ? (change.rationale_bullets as unknown[]).map((v) => String(v)).join(" • ") : "—",
+            evidence_refs: Array.isArray(change.evidence_references) ? (change.evidence_references as unknown[]).map((v) => String(v)).join("; ") : "—",
+            impact_preview: `${formatCurrency(asNumber(asRecord(change.preview_payload)?.base_iv))} → ${formatCurrency(asNumber(asRecord(change.preview_payload)?.preview_iv))} (${formatPercent(asNumber(asRecord(change.preview_payload)?.delta_pct))})`,
             status: change.status,
+            actions: change.change_id,
           })),
           [
             { key: "id", label: "ID", kind: "number" },
-            { key: "field", label: "Field", kind: "text" },
-            { key: "current", label: "Current", kind: "number" },
-            { key: "proposed", label: "Proposed", kind: "number" },
-            { key: "source", label: "Source", kind: "text" },
+            { key: "proposed_change", label: "Proposed Change", kind: "text" },
             { key: "confidence", label: "Confidence", kind: "text" },
+            { key: "why", label: "Why", kind: "text" },
+            { key: "evidence_refs", label: "Evidence Refs", kind: "text" },
+            { key: "impact_preview", label: "Impact Preview", kind: "text" },
             { key: "status", label: "Status", kind: "text" },
+            { key: "actions", label: "Actions", kind: "text" },
           ],
         )}
+        <div className="action-controls">
+          {pendingChanges.map((change) => (
+            <div key={`pending-actions-${String(change.change_id)}`}>
+              <strong>#{String(change.change_id)}</strong>{" "}
+              <button type="button" className="ghost-button" onClick={() => onPendingAction("apply", Number(change.change_id))}>Approve</button>{" "}
+              <button type="button" className="ghost-button" onClick={() => onPendingAction("reject", Number(change.change_id))}>Reject</button>{" "}
+              <button type="button" className="ghost-button" onClick={() => onPendingAction("defer", Number(change.change_id))}>Defer</button>
+            </div>
+          ))}
+        </div>
       </section>
       <section className="stacked-cards">
         {fields.map((field) => {
@@ -1511,6 +1526,13 @@ export function ValuationPage() {
     mutationFn: () => applyRecommendations(ticker, { approved_fields: selectedRecommendationFields }),
     onSuccess: (payload) => setRecommendationsRunId(payload.run_id),
   });
+  const pendingActionMutation = useMutation({
+    mutationFn: ({ action, changeId }: { action: "apply" | "reject" | "defer"; changeId: number }) =>
+      applyPendingChangesAction(ticker, action, { change_ids: [changeId] }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["ticker-valuation-assumptions", ticker] }).catch(() => undefined);
+    },
+  });
   const exportMutation = useMutation({
     mutationFn: () => createTickerExport(ticker, { format: "xlsx", source_mode: "loaded_backend_state" }),
     onSuccess: (payload) => setExportRunId(payload.run_id),
@@ -1616,6 +1638,7 @@ export function ValuationPage() {
             previewPending={assumptionsPreviewMutation.isPending}
             onPreview={() => assumptionsPreviewMutation.mutate()}
             onApply={() => assumptionsApplyMutation.mutate()}
+            onPendingAction={(action, changeId) => pendingActionMutation.mutate({ action, changeId })}
             applyPending={assumptionsApplyMutation.isPending}
             runStatus={assumptionsRunStatusQuery.data as unknown as Record<string, unknown> | undefined}
           />
@@ -1668,6 +1691,7 @@ export function ValuationPage() {
     dcf,
     dcfQuery.isPending,
     recommendationsApplyMutation,
+    pendingActionMutation,
     recommendationsPreviewMutation,
     recommendationsQuery.data,
     recommendationsQuery.isPending,

--- a/src/contracts/assumption_policy.py
+++ b/src/contracts/assumption_policy.py
@@ -18,6 +18,7 @@ class PendingAssumptionStatus(str, Enum):
     pending = "pending"
     approved = "approved"
     rejected = "rejected"
+    deferred = "deferred"
     superseded = "superseded"
 
 

--- a/src/stage_04_pipeline/pending_assumption_changes.py
+++ b/src/stage_04_pipeline/pending_assumption_changes.py
@@ -150,6 +150,30 @@ def preview_pending_assumption_stack(
     )
 
 
+def list_pending_assumption_changes_with_preview(ticker: str) -> list[dict[str, Any]]:
+    pending = list_pending_assumption_changes(ticker)
+    enriched: list[dict[str, Any]] = []
+    for change in pending:
+        preview = preview_pending_assumption_stack(ticker, [int(change.change_id or 0)])
+        base_iv = preview.current_iv.get("base")
+        preview_iv = preview.proposed_iv.get("base")
+        delta_iv = round(preview_iv - base_iv, 2) if isinstance(base_iv, (int, float)) and isinstance(preview_iv, (int, float)) else None
+        enriched.append(
+            {
+                **change.model_dump(),
+                "rationale_bullets": [item.strip("-• ").strip() for item in str(change.rationale or "").splitlines() if item.strip()],
+                "evidence_references": [item.strip() for item in str(change.citation or "").split(";") if item.strip()],
+                "preview_payload": {
+                    "base_iv": base_iv,
+                    "preview_iv": preview_iv,
+                    "delta_iv": delta_iv,
+                    "delta_pct": preview.delta_pct.get("base"),
+                },
+            }
+        )
+    return enriched
+
+
 def apply_pending_assumption_stack(
     ticker: str,
     change_ids: list[int],
@@ -157,18 +181,16 @@ def apply_pending_assumption_stack(
     actor: str = "api",
 ) -> dict[str, Any]:
     applied_at = _now()
-    approval_ref = f"assumption_register_apply:{ticker.upper()}:{applied_at}"
     with get_connection() as conn:
         create_tables(conn)
-        from db.loader import apply_pending_assumption_changes, insert_assumption_register_audit
+        from db.loader import insert_assumption_register_audit, transition_pending_assumption_changes_status
 
-        approved = apply_pending_assumption_changes(
+        approved = transition_pending_assumption_changes_status(
             conn,
             ticker=ticker,
             change_ids=change_ids,
-            actor=actor,
-            applied_at=applied_at,
-            approval_ref=approval_ref,
+            status="approved",
+            updated_at=applied_at,
         )
         audit_rows = []
         for row in approved:
@@ -182,8 +204,8 @@ def apply_pending_assumption_stack(
                     "ticker": ticker.upper(),
                     "assumption_name": row["assumption_name"],
                     "scope": "dcf",
-                    "event_type": "pm_override_applied",
-                    "changed_fields": {"current_value": {"prior": None, "new": row["proposed_value"]}},
+                    "event_type": "pending_change_approved",
+                    "changed_fields": {"status": {"prior": "pending", "new": "approved"}},
                     "valuation_impact": None,
                     "reason": row.get("source_ref"),
                 }
@@ -193,9 +215,48 @@ def apply_pending_assumption_stack(
         "ticker": ticker.upper(),
         "applied_count": len(approved),
         "change_ids": [row["change_id"] for row in approved],
-        "approval_ref": approval_ref,
         "actor": actor,
     }
+
+
+def transition_pending_assumption_statuses(
+    ticker: str,
+    change_ids: list[int],
+    *,
+    target_status: str,
+    actor: str = "api",
+) -> dict[str, Any]:
+    updated_at = _now()
+    with get_connection() as conn:
+        create_tables(conn)
+        from db.loader import insert_assumption_register_audit, transition_pending_assumption_changes_status
+
+        changed = transition_pending_assumption_changes_status(
+            conn,
+            ticker=ticker,
+            change_ids=change_ids,
+            status=target_status,
+            updated_at=updated_at,
+        )
+        audit_rows = [
+            {
+                "event_ts": updated_at,
+                "actor": actor,
+                "actor_type": "pm" if actor != "system" else "system",
+                "entity_type": "ticker",
+                "entity_id": ticker.upper(),
+                "ticker": ticker.upper(),
+                "assumption_name": row["assumption_name"],
+                "scope": "dcf",
+                "event_type": f"pending_change_{target_status}",
+                "changed_fields": {"status": {"prior": "pending", "new": target_status}},
+                "valuation_impact": None,
+                "reason": row.get("source_ref"),
+            }
+            for row in changed
+        ]
+        insert_assumption_register_audit(conn, audit_rows)
+    return {"ticker": ticker.upper(), "changed_count": len(changed), "change_ids": [row["change_id"] for row in changed], "status": target_status}
 
 
 def approved_assumption_overrides_for_ticker(ticker: str) -> dict[str, float]:


### PR DESCRIPTION
### Motivation
- Surface pending assumption changes in the Valuation UI as a minimal approval card showing the proposed change, confidence, rationale bullets, evidence refs, and an impact preview so a PM can act quickly.  
- Provide a deterministic preview simulation path that does not persist approved assumptions.  
- Ensure UI actions only transition pending-entry status and emit audit events rather than implicitly persisting domain overrides.

### Description
- Added enriched pending-change listing `list_pending_assumption_changes_with_preview` which attaches `rationale_bullets`, `evidence_references`, and a deterministic `preview_payload` (`base_iv`, `preview_iv`, `delta_iv`, `delta_pct`) assembled by `preview_pending_assumption_stack` (see `src/stage_04_pipeline/pending_assumption_changes.py`).
- Introduced a generic DB helper `transition_pending_assumption_changes_status` to atomically move pending rows and return enriched rows, and surfaced a `deferred` status in the contract enum (`db/loader.py`, `src/contracts/assumption_policy.py`).
- Changed the approve flow to perform a status transition + audit-only event (no approved-assumption persistence) and added endpoints `POST /api/tickers/{ticker}/valuation/pending-changes/reject` and `.../defer` run as background jobs (`api/main.py`, `src/stage_04_pipeline/pending_assumption_changes.py`).
- Updated frontend API client and Valuation → Assumptions UI to render the approval card fields and provide `Approve`/`Reject`/`Defer` buttons wired to `applyPendingChangesAction` and a new mutation (`frontend/src/lib/api.ts`, `frontend/src/pages/ValuationPage.tsx`).

### Testing
- Ran the frontend route test with `npm --prefix frontend run test -- src/test/appRoutes.test.tsx` which passed (`1 file, 11 tests` passed).  
- Attempted component test `npm --prefix frontend run test -- ValuationPage --runInBand` but it failed due to an invalid Vitest CLI flag (`--runInBand`).  
- Ran `python -m pytest -q tests -k pending_assumption -q` but collection failed due to environment issues (missing `edgar` package, missing LLM API keys, and external network/proxy errors), so backend unit tests could not be fully exercised in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ee6f2935c832fb72176316b7abb97)