### PR TITLE
Add structured QoEProposal contract with validation and Stage 04 mapping

### DIFF
--- a/src/contracts/assumption_policy.py
+++ b/src/contracts/assumption_policy.py
@@ -107,6 +107,59 @@ class PendingAssumptionChange(ContractModel):
         return cleaned
 
 
+
+
+class QoEProposalStatus(str, Enum):
+    pending = "pending"
+    approved = "approved"
+    rejected = "rejected"
+
+
+class QoEProposal(ContractModel):
+    ticker: str
+    ebit_adjustment_pct: float = Field(ge=-0.20, le=0.20)
+    normalized_ebit: float
+    confidence: float = Field(ge=0.0, le=1.0)
+    rationale_bullets: list[str] = Field(min_length=1)
+    evidence_refs: list[str] = Field(min_length=1)
+    status: QoEProposalStatus = QoEProposalStatus.pending
+
+    @field_validator("ticker")
+    @classmethod
+    def _uppercase_qoe_ticker(cls, value: str) -> str:
+        return str(value).upper().strip()
+
+    @field_validator("rationale_bullets", "evidence_refs")
+    @classmethod
+    def _strip_non_empty_items(cls, values: list[str]) -> list[str]:
+        cleaned = [str(v).strip() for v in values if str(v).strip()]
+        if not cleaned:
+            raise ValueError("at least one non-empty value is required")
+        return cleaned
+
+
+def qoe_proposal_to_api_payload(proposal: QoEProposal) -> dict[str, Any]:
+    return proposal.model_dump()
+
+
+def qoe_proposal_to_pending_change_payload(proposal: QoEProposal) -> dict[str, Any]:
+    return {
+        "ticker": proposal.ticker,
+        "assumption_name": "ebit_margin_start",
+        "proposed_value": proposal.normalized_ebit,
+        "source_type": PendingAssumptionSourceType.agent.value,
+        "source_ref": "qoe",
+        "confidence": f"{proposal.confidence:.2f}",
+        "rationale": " | ".join(proposal.rationale_bullets),
+        "citation": "; ".join(proposal.evidence_refs),
+        "status": proposal.status.value,
+        "metadata": {
+            "qoe_proposal": proposal.model_dump(),
+            "ebit_adjustment_pct": proposal.ebit_adjustment_pct,
+        },
+    }
+
+
 class PendingAssumptionStackPreview(ContractModel):
     ticker: str
     selected_change_ids: list[int] = Field(default_factory=list)

--- a/src/stage_04_pipeline/pending_assumption_changes.py
+++ b/src/stage_04_pipeline/pending_assumption_changes.py
@@ -9,6 +9,8 @@ from src.contracts.assumption_policy import (
     PendingAssumptionChange,
     PendingAssumptionSourceType,
     PendingAssumptionStackPreview,
+    QoEProposal,
+    qoe_proposal_to_pending_change_payload,
 )
 from src.stage_02_valuation.professional_dcf import default_scenario_specs, run_dcf_professional
 
@@ -56,9 +58,25 @@ def write_pending_changes_from_recommendations(ticker: str, recommendations: lis
         key = (str(getattr(rec, "field", "")), str(getattr(rec, "agent", "agent")), round(float(proposed), 12))
         if key in existing:
             continue
-        created.append(
-            create_pending_assumption_change(
-                PendingAssumptionChange(
+        if str(getattr(rec, "agent", "")).lower() == "qoe" and str(getattr(rec, "field", "")) == "ebit_margin_start":
+            qoe_proposal_raw = (getattr(rec, "qoe_proposal", None) or {}).copy() if isinstance(getattr(rec, "qoe_proposal", None), dict) else None
+            if qoe_proposal_raw:
+                proposal = QoEProposal.model_validate(qoe_proposal_raw)
+                payload = qoe_proposal_to_pending_change_payload(proposal)
+                change = PendingAssumptionChange(
+                    ticker=payload["ticker"],
+                    assumption_name=payload["assumption_name"],
+                    current_value=getattr(rec, "current_value", None),
+                    proposed_value=float(proposed),
+                    source_type=PendingAssumptionSourceType.agent,
+                    source_ref=payload["source_ref"],
+                    confidence=payload["confidence"],
+                    rationale=payload["rationale"],
+                    citation=payload["citation"],
+                    metadata={**payload.get("metadata", {}), "legacy_recommendation_status": getattr(rec, "status", "pending")},
+                )
+            else:
+                change = PendingAssumptionChange(
                     ticker=ticker,
                     assumption_name=str(getattr(rec, "field", "")),
                     current_value=getattr(rec, "current_value", None),
@@ -70,8 +88,20 @@ def write_pending_changes_from_recommendations(ticker: str, recommendations: lis
                     citation=getattr(rec, "citation", None),
                     metadata={"legacy_recommendation_status": getattr(rec, "status", "pending")},
                 )
+        else:
+            change = PendingAssumptionChange(
+                ticker=ticker,
+                assumption_name=str(getattr(rec, "field", "")),
+                current_value=getattr(rec, "current_value", None),
+                proposed_value=float(proposed),
+                source_type=PendingAssumptionSourceType.agent,
+                source_ref=str(getattr(rec, "agent", "agent")),
+                confidence=getattr(rec, "confidence", None),
+                rationale=getattr(rec, "rationale", None),
+                citation=getattr(rec, "citation", None),
+                metadata={"legacy_recommendation_status": getattr(rec, "status", "pending")},
             )
-        )
+        created.append(create_pending_assumption_change(change))
         existing.add(key)
     return created
 

--- a/src/stage_04_pipeline/recommendations.py
+++ b/src/stage_04_pipeline/recommendations.py
@@ -24,6 +24,7 @@ from src.stage_02_valuation.professional_dcf import (
     run_dcf_professional,
 )
 from src.stage_02_valuation.valuation_types import ForecastDrivers
+from src.contracts.assumption_policy import QoEProposal, QoEProposalStatus
 
 RECS_DIR = ROOT_DIR / "config"
 OVERRIDES_PATH = ROOT_DIR / "config" / "valuation_overrides.yaml"
@@ -41,6 +42,7 @@ class Recommendation:
     rationale: str
     citation: str | None = None
     status: str = "pending"   # "pending" | "approved" | "rejected"
+    qoe_proposal: dict[str, Any] | None = None
 
 
 @dataclass
@@ -83,6 +85,7 @@ def _recs_to_dict(recs: TickerRecommendations) -> dict:
                 "rationale": r.rationale,
                 "citation": r.citation,
                 "status": r.status,
+                "qoe_proposal": r.qoe_proposal,
             }
             for r in recs.recommendations
         ],
@@ -104,11 +107,43 @@ def _recs_from_dict(data: dict) -> TickerRecommendations:
                 rationale=r.get("rationale", ""),
                 citation=r.get("citation"),
                 status=r.get("status", "pending"),
+                qoe_proposal=r.get("qoe_proposal"),
             )
             for r in (data.get("recommendations") or [])
         ],
     )
 
+
+
+
+def _confidence_label_to_score(value: Any) -> float:
+    mapping = {"high": 0.9, "medium": 0.6, "low": 0.3}
+    if isinstance(value, (int, float)):
+        return max(0.0, min(1.0, float(value)))
+    return mapping.get(str(value).strip().lower(), 0.3)
+
+
+def _build_qoe_proposal(ticker: str, llm: dict[str, Any], normalized_ebit: float) -> QoEProposal:
+    haircut_pct = llm.get("ebit_haircut_pct")
+    haircut_decimal = float(haircut_pct) / 100.0 if isinstance(haircut_pct, (int, float)) else 0.0
+    adjustments = llm.get("ebit_adjustments") or []
+    rationale = [
+        f"{a.get('item', 'adjustment')}: {a.get('rationale', '').strip() or 'management adjustment'}"
+        for a in adjustments[:3]
+        if isinstance(a, dict)
+    ]
+    if not rationale:
+        rationale = [f"QoE EBIT normalisation adjustment {haircut_pct:+.1f}%" if isinstance(haircut_pct, (int, float)) else "QoE EBIT normalisation adjustment"]
+    evidence_refs = [f"qoe_adjustment:{a.get('item','unknown')}" for a in adjustments[:3] if isinstance(a, dict)] or ["qoe_agent_output"]
+    return QoEProposal(
+        ticker=ticker,
+        ebit_adjustment_pct=haircut_decimal,
+        normalized_ebit=float(normalized_ebit),
+        confidence=_confidence_label_to_score(llm.get("llm_confidence")),
+        rationale_bullets=rationale,
+        evidence_refs=evidence_refs,
+        status=QoEProposalStatus.pending,
+    )
 
 # ── Main extraction ────────────────────────────────────────────────────────────
 
@@ -156,6 +191,7 @@ def extract_recommendations(
             if normalized_ebit and revenue_base and revenue_base > 0:
                 proposed_margin = round(float(normalized_ebit) / float(revenue_base), 6)
             if proposed_margin is not None:
+                qoe_proposal = _build_qoe_proposal(ticker, llm, float(normalized_ebit))
                 adjustments = llm.get("ebit_adjustments") or []
                 if adjustments:
                     rationale = (
@@ -177,7 +213,9 @@ def extract_recommendations(
                     proposed_value=proposed_margin,
                     confidence=llm.get("llm_confidence") or "medium",
                     rationale=rationale,
+                    citation="; ".join(qoe_proposal.evidence_refs),
                     status=existing_statuses.get(key, "pending"),
+                    qoe_proposal=qoe_proposal.model_dump(),
                 ))
 
     # ── AccountingRecast → EV bridge items + optional EBIT ───────────────────

--- a/tests/test_assumption_policy.py
+++ b/tests/test_assumption_policy.py
@@ -5,6 +5,9 @@ import pytest
 from db.schema import create_tables
 from src.contracts.assumption_policy import (
     PendingAssumptionChange,
+    QoEProposal,
+    qoe_proposal_to_api_payload,
+    qoe_proposal_to_pending_change_payload,
     ValuationPolicy,
     ValuationPolicyGlobalDefaults,
 )
@@ -115,3 +118,58 @@ def test_pending_change_apply_creates_active_approved_entry():
 
     assert applied[0]["assumption_name"] == "ebit_margin_start"
     assert active[0]["value"] == pytest.approx(0.21)
+
+
+def test_qoe_proposal_contract_validation_and_serialization():
+    proposal = QoEProposal(
+        ticker="ibm",
+        ebit_adjustment_pct=-0.12,
+        normalized_ebit=1_250_000_000.0,
+        confidence=0.8,
+        rationale_bullets=["Removed restructuring charge from run-rate EBIT"],
+        evidence_refs=["10K-2025-note-12"],
+        status="pending",
+    )
+
+    api_payload = qoe_proposal_to_api_payload(proposal)
+    db_payload = qoe_proposal_to_pending_change_payload(proposal)
+
+    assert proposal.ticker == "IBM"
+    assert api_payload["confidence"] == pytest.approx(0.8)
+    assert db_payload["assumption_name"] == "ebit_margin_start"
+    assert db_payload["metadata"]["qoe_proposal"]["evidence_refs"] == ["10K-2025-note-12"]
+
+
+def test_qoe_proposal_enforces_bounds_and_evidence_refs():
+    with pytest.raises(Exception):
+        QoEProposal(
+            ticker="IBM",
+            ebit_adjustment_pct=-0.25,
+            normalized_ebit=100.0,
+            confidence=0.5,
+            rationale_bullets=["test"],
+            evidence_refs=["ref"],
+            status="pending",
+        )
+
+    with pytest.raises(Exception):
+        QoEProposal(
+            ticker="IBM",
+            ebit_adjustment_pct=-0.1,
+            normalized_ebit=100.0,
+            confidence=1.1,
+            rationale_bullets=["test"],
+            evidence_refs=["ref"],
+            status="pending",
+        )
+
+    with pytest.raises(Exception):
+        QoEProposal(
+            ticker="IBM",
+            ebit_adjustment_pct=-0.1,
+            normalized_ebit=100.0,
+            confidence=0.7,
+            rationale_bullets=["test"],
+            evidence_refs=[],
+            status="pending",
+        )


### PR DESCRIPTION
### Motivation
- Provide a typed, validated contract for Quality-of-Earnings (QoE) outputs so downstream systems (Stage 03/Stage 04) receive structured proposals that can be serialized and persisted reliably.
- Ensure QoE numeric adjustments and evidence are bounded and non-empty to reduce silent failures and improve PM review quality.
- Map LLM QoE outputs into the existing pending-assumption workflow so PM-approved normalisations can be applied to the valuation input pipeline in a safe, auditable way.

### Description
- Added `QoEProposal` and `QoEProposalStatus` to `src/contracts/assumption_policy.py` with required fields `ticker`, `ebit_adjustment_pct`, `normalized_ebit`, `confidence`, `rationale_bullets`, `evidence_refs`, and `status`, plus validators that uppercase `ticker`, enforce `confidence` in `[0,1]`, `ebit_adjustment_pct` in `[-0.20, +0.20]`, and require non-empty `rationale_bullets`/`evidence_refs`.
- Implemented two serialization helpers `qoe_proposal_to_api_payload(...)` and `qoe_proposal_to_pending_change_payload(...)` for API responses and DB/pending-change payloads respectively.
- Updated `src/stage_04_pipeline/recommendations.py` to construct a `QoEProposal` from LLM outputs (`_build_qoe_proposal`) and to carry a structured `qoe_proposal` blob on `Recommendation` records and YAML serialization.
- Updated `src/stage_04_pipeline/pending_assumption_changes.py` to detect QoE recommendation rows, validate the embedded `qoe_proposal`, and map it into a `PendingAssumptionChange` payload (falling back to legacy behavior when structured payloads are absent).
- Added unit tests in `tests/test_assumption_policy.py` to cover `QoEProposal` validation and both API/DB serialization helpers.

### Testing
- Ran `python -m pytest -q tests/test_assumption_policy.py` which passed (`7 passed`).
- Attempted `python -m pytest -q tests/test_recommendations.py tests/test_assumption_policy.py` but test collection failed in this environment with `ModuleNotFoundError: No module named 'edgar'`, an external dependency unrelated to the changes in this PR, so a broader test run could not complete here.
- Focused contract tests validate the new schema and mapping behavior; integration tests that touch EDGAR/filing retrieval require the `edgar` dependency or a mocked environment to complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ee6f0f070832fbfc8a8e8331ba455)