### PR TITLE
Route QoE proposals into pending-assumption queue

### DIFF
--- a/src/stage_02_valuation/batch_runner.py
+++ b/src/stage_02_valuation/batch_runner.py
@@ -133,10 +133,10 @@ def _sensitivity_rows(ticker: str, drivers: ForecastDrivers) -> list[dict]:
 
 def _run_qoe_llm(ticker: str, valuation_result: dict) -> None:
     """
-    Run QoEAgent (LLM layer) for a ticker and write pending override to
-    config/qoe_pending.yaml.  PM sets status → 'approved' to apply on next run.
+    Run QoEAgent (LLM layer) for a ticker and persist a pending assumption
+    change proposal in the canonical register queue.
     """
-    from src.stage_03_judgment.qoe_agent import QoEAgent, write_qoe_pending_override
+    from src.stage_03_judgment.qoe_agent import QoEAgent, create_qoe_pending_change
 
     ticker = ticker.upper().strip()
     revenue_mm = valuation_result.get("revenue_mm") or 0.0
@@ -204,18 +204,19 @@ def _run_qoe_llm(ticker: str, valuation_result: dict) -> None:
                     extra={"ticker": ticker, "step": "qoe_llm"},
                 )
 
-        path = write_qoe_pending_override(ticker, qoe, revenue_mm)
+        proposal = create_qoe_pending_change(ticker, qoe, revenue_mm)
 
         if pending:
             logger.warning(
-                "\n  Override warranted (haircut >%s%% > 10%% threshold)\n  → Review config/qoe_pending.yaml\n  → Set status: approved  to apply on next --json run",
+                "\n  Override warranted (haircut >%s%% > 10%% threshold)\n  → Review pending assumption queue entry %s\n  → Manual PM approval is required before apply",
                 f"{abs(haircut):.0f}",
+                proposal.change_id if proposal else "n/a",
                 extra={"ticker": ticker, "step": "qoe_llm"},
             )
         else:
             logger.info(
-                "\n  Haircut below 10%% threshold — no override needed\n  → Logged to %s (status: pending)",
-                path,
+                "\n  Haircut below 10%% threshold — proposal remains advisory\n  → Pending assumption change id: %s",
+                proposal.change_id if proposal else "n/a",
                 extra={"ticker": ticker, "step": "qoe_llm"},
             )
 

--- a/src/stage_03_judgment/qoe_agent.py
+++ b/src/stage_03_judgment/qoe_agent.py
@@ -16,20 +16,15 @@ from __future__ import annotations
 
 import os
 from datetime import datetime
-from pathlib import Path
 from typing import Any
-
-import yaml
 
 from src.stage_03_judgment.base_agent import BaseAgent
 from src.stage_03_judgment.qoe_signals import compute_qoe_signals
 from src.stage_00_data import edgar_client, filing_retrieval
 from src.stage_00_data import market_data as md_client
 from src.stage_00_data.ciq_adapter import get_ciq_snapshot, get_ciq_nwc_history
-
-_ROOT = Path(__file__).resolve().parent.parent.parent
-QOE_PENDING_PATH = _ROOT / "config" / "qoe_pending.yaml"
-
+from src.contracts.assumption_policy import PendingAssumptionChange, PendingAssumptionSourceType
+from src.stage_04_pipeline.pending_assumption_changes import create_pending_assumption_change
 
 SYSTEM_PROMPT = """You are a buy-side accounting analyst specialising in quality-of-earnings (QoE) analysis.
 
@@ -392,19 +387,14 @@ class QoEAgent(BaseAgent):
         )
 
 
-def write_qoe_pending_override(
+def create_qoe_pending_change(
     ticker: str,
     qoe_result: dict,
     revenue_mm: float,
-) -> Path:
+) -> PendingAssumptionChange | None:
     """
-    Write QoE LLM normalisation recommendation to config/qoe_pending.yaml.
-
-    Status starts as 'pending'. PM sets status → 'approved' to apply the
-    suggested_override on the next batch_runner --json run.
-    Status → 'rejected' suppresses future writes for this ticker until cleared.
-
-    Returns the path written.
+    Create a canonical pending assumption change from QoE output.
+    Returns None when no margin proposal can be derived.
     """
     ticker = ticker.upper().strip()
     llm = qoe_result.get("llm", {})
@@ -412,80 +402,40 @@ def write_qoe_pending_override(
     reported_ebit = llm.get("reported_ebit") or 0.0
     normalized_ebit = llm.get("normalized_ebit") or reported_ebit
     haircut_pct = llm.get("ebit_haircut_pct")
-    pending_flag = llm.get("dcf_ebit_override_pending", False)
+    pending_flag = bool(llm.get("dcf_ebit_override_pending", False))
 
     # Convert absolute EBIT to margin using LTM revenue
     rev = revenue_mm * 1_000_000 if revenue_mm else 0.0
     reported_margin = round(reported_ebit / rev, 6) if rev else None
     normalized_margin = round(normalized_ebit / rev, 6) if rev else None
 
-    # Load existing pending file (preserve other tickers' entries)
-    existing: dict = {}
-    if QOE_PENDING_PATH.exists():
-        with QOE_PENDING_PATH.open("r", encoding="utf-8") as f:
-            existing = yaml.safe_load(f) or {}
+    if normalized_margin is None:
+        return None
 
-    # Don't overwrite a PM decision (approved/rejected) with a fresh run
-    prev_status = (existing.get(ticker) or {}).get("status", "pending")
-    if prev_status in {"approved", "rejected"}:
-        # Preserve the PM decision; just refresh metadata
-        existing.setdefault(ticker, {})["last_refreshed_at"] = (
-            datetime.utcnow().isoformat(timespec="seconds")
-        )
-        QOE_PENDING_PATH.write_text(
-            yaml.dump(
-                existing, default_flow_style=False, allow_unicode=True, sort_keys=False
-            ),
-            encoding="utf-8",
-        )
-        return QOE_PENDING_PATH
-
-    entry: dict = {
-        "generated_at": datetime.utcnow().isoformat(timespec="seconds"),
-        "qoe_score": qoe_result.get("qoe_score"),
-        "qoe_flag": qoe_result.get("qoe_flag"),
-        "confidence": llm.get("llm_confidence", "low"),
-        "reported_ebit_mm": round(reported_ebit / 1_000_000, 2)
-        if reported_ebit
-        else None,
+    proposal_id = f"qoe:{ticker}:{datetime.utcnow().isoformat(timespec='seconds')}"
+    evidence = {
+        "reported_ebit_mm": round(reported_ebit / 1_000_000, 2) if reported_ebit else None,
         "reported_ebit_margin": reported_margin,
-        "normalized_ebit_mm": round(normalized_ebit / 1_000_000, 2)
-        if normalized_ebit
-        else None,
+        "normalized_ebit_mm": round(normalized_ebit / 1_000_000, 2) if normalized_ebit else None,
         "normalized_ebit_margin": normalized_margin,
         "ebit_haircut_pct": haircut_pct,
         "override_warranted": pending_flag,
-        "adjustments": [
-            {
-                "item": a["item"],
-                "amount_mm": round(a["amount"] / 1_000_000, 2)
-                if a["amount"] > 1_000
-                else a["amount"],
-                "direction": a["direction"],
-                "rationale": a["rationale"],
-            }
-            for a in llm.get("ebit_adjustments", [])
-        ],
+        "adjustments": llm.get("ebit_adjustments", []),
         "revenue_recognition_flags": llm.get("revenue_recognition_flags", []),
         "auditor_flags": llm.get("auditor_flags", []),
         "pm_summary": qoe_result.get("pm_summary", ""),
-        # ── PM APPROVAL BLOCK ────────────────────────────────────────────────
-        # To apply: set status → 'approved', then re-run:
-        #   python -m src.stage_02_valuation.batch_runner --ticker TICKER --json
-        # To reject without applying: set status → 'rejected'
-        "suggested_override": {
-            "ebit_margin_start": normalized_margin,
-        }
-        if normalized_margin is not None
-        else {},
-        "status": "pending",  # pending | approved | rejected
     }
-
-    existing[ticker] = entry
-    QOE_PENDING_PATH.write_text(
-        yaml.dump(
-            existing, default_flow_style=False, allow_unicode=True, sort_keys=False
-        ),
-        encoding="utf-8",
+    return create_pending_assumption_change(
+        PendingAssumptionChange(
+            ticker=ticker,
+            assumption_name="ebit_margin_start",
+            current_value=reported_margin,
+            proposed_value=float(normalized_margin),
+            source_type=PendingAssumptionSourceType.agent,
+            source_ref=proposal_id,
+            confidence=llm.get("llm_confidence", "low"),
+            rationale=qoe_result.get("pm_summary", "") or "QoE EBIT normalisation proposal",
+            status="pending",
+            metadata=evidence,
+        )
     )
-    return QOE_PENDING_PATH

--- a/src/stage_04_pipeline/orchestrator.py
+++ b/src/stage_04_pipeline/orchestrator.py
@@ -29,7 +29,7 @@ from src.stage_03_judgment.accounting_recast_agent import (
 from src.stage_03_judgment.earnings_agent import EarningsAgent
 from src.stage_03_judgment.filings_agent import FilingsAgent
 from src.stage_03_judgment.industry_agent import IndustryAgent
-from src.stage_03_judgment.qoe_agent import QoEAgent
+from src.stage_03_judgment.qoe_agent import QoEAgent, create_qoe_pending_change
 from src.stage_03_judgment.risk_agent import RiskAgent
 from src.stage_03_judgment.risk_impact_agent import RiskImpactAgent
 from src.stage_03_judgment.sentiment_agent import SentimentAgent
@@ -393,8 +393,14 @@ class PipelineOrchestrator:
             self.last_qoe_result = qoe_result
             llm_block = qoe_result.get("llm") or {}
             pending = llm_block.get("dcf_ebit_override_pending", False)
+            revenue_mm = (hist.get("revenue") or [0.0])[0] / 1_000_000 if (hist.get("revenue") or []) else 0.0
+            proposal = create_qoe_pending_change(ticker=ticker, qoe_result=qoe_result, revenue_mm=float(revenue_mm))
+            if proposal:
+                self._on_warn(
+                    f"QoE proposal queued (change_id={proposal.change_id}, source_ref={proposal.source_ref}) — pending review only; no automatic apply"
+                )
             if pending:
-                self._on_warn("EBIT haircut >10% — review and manually approve any override in config/valuation_overrides.yaml before acting")
+                self._on_warn("EBIT haircut >10% — proposal is pending only; manual PM approval in pending-change queue is required before apply")
             det = qoe_result.get("deterministic") or {}
             signal_scores = det.get("signal_scores") or {}
             flags = [f"{k}: {v}" for k, v in signal_scores.items() if v in ("amber", "red")]

--- a/tests/test_qoe_agent.py
+++ b/tests/test_qoe_agent.py
@@ -9,7 +9,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from src.stage_00_data import edgar_client
-from src.stage_03_judgment.qoe_agent import QoEAgent
+from src.stage_03_judgment.qoe_agent import QoEAgent, create_qoe_pending_change
 
 
 # ── Schema helpers ─────────────────────────────────────────────────────────────
@@ -291,3 +291,36 @@ def test_qoe_agent_revenue_recognition_flags_passed_through(monkeypatch):
     assert len(out["llm"]["revenue_recognition_flags"]) == 2
     assert len(out["llm"]["auditor_flags"]) == 1
     assert out["llm"]["narrative_credibility"] == "low"
+
+
+def test_create_qoe_pending_change_persists_pending_queue_record(monkeypatch):
+    captured = {}
+
+    def _fake_create(change):
+        captured["change"] = change
+        return change.model_copy(update={"change_id": 999})
+
+    monkeypatch.setattr("src.stage_03_judgment.qoe_agent.create_pending_assumption_change", _fake_create)
+    proposal = create_qoe_pending_change(
+        "test",
+        {
+            "qoe_score": 4,
+            "qoe_flag": "amber",
+            "pm_summary": "normalize for non-recurring gain",
+            "llm": {
+                "reported_ebit": 120_000_000.0,
+                "normalized_ebit": 108_000_000.0,
+                "ebit_haircut_pct": -10.0,
+                "dcf_ebit_override_pending": True,
+                "llm_confidence": "medium",
+                "ebit_adjustments": [{"item": "gain", "amount": 12_000_000.0, "direction": "-", "rationale": "one-off"}],
+                "revenue_recognition_flags": [],
+                "auditor_flags": [],
+            },
+        },
+        revenue_mm=1000.0,
+    )
+    assert proposal is not None
+    assert proposal.change_id == 999
+    assert proposal.status.value == "pending"
+    assert captured["change"].assumption_name == "ebit_margin_start"


### PR DESCRIPTION
### Motivation

- Prevent LLM judgment from directly mutating deterministic valuation assumptions by routing QoE normalization proposals into the canonical pending-change register for PM review. 
- Provide audit-friendly identifiers and guardrails so proposals are traceable and never auto-applied by orchestration. 

### Description

- Replace the legacy QoE YAML writer with `create_qoe_pending_change` that builds a `PendingAssumptionChange` (including `confidence`, `rationale`, and `metadata`) and persists via `create_pending_assumption_change` in `src/stage_03_judgment/qoe_agent.py`. 
- Update orchestration in `src/stage_04_pipeline/orchestrator.py` to enqueue QoE proposals (using `create_qoe_pending_change`), emit stable identifiers (`change_id`/`source_ref`) in logs, and warn that proposals are pending-only (no automatic apply). 
- Update batch QoE path in `src/stage_02_valuation/batch_runner.py` to call the canonical proposal flow and adjust operator messages to require manual PM approval from the pending-change queue. 
- Add unit coverage in `tests/test_qoe_agent.py` for `create_qoe_pending_change` to assert a pending queue record is created with the target `assumption_name` and `status='pending'`.

### Testing

- Ran `python -m compileall` against changed modules (`src/stage_03_judgment/qoe_agent.py`, `src/stage_04_pipeline/orchestrator.py`, `src/stage_02_valuation/batch_runner.py`, `tests/test_qoe_agent.py`) and compilation succeeded. 
- Ran `pytest` for the QoE tests but collection failed in this environment due to a missing external dependency (`ModuleNotFoundError: No module named 'edgar'`), so the full test run could not complete here. 
- Added a focused unit test `test_create_qoe_pending_change_persists_pending_queue_record` which is expected to pass when run in an environment with test dependencies available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ee6f188f0832f8fd0ae8ba6117984)