### PR TITLE
chore: record M1 merge handoff in session state

### DIFF
--- a/.agent/session-state.md
+++ b/.agent/session-state.md
@@ -25,17 +25,28 @@ backend-full-tests deep gate). Local repo is on a clean `main`;
 2. Sessions 1-4 (July): the M1 exit criteria clock. Real tickers, friction log per session.
 3. Suggested agent routing for live sessions:
    `--use-openrouter-free --openrouter-model "openai/gpt-oss-120b:free" --openrouter-fallback-models "openai/gpt-oss-120b"`
-   (requires OPENROUTER_API_KEY in env; run banner now displays effective routing —
-   confirm model+cost with PM before any live-agent run, see Claude memory codex-model-routing).
+   (requires OPENROUTER_API_KEY in env; run banner now displays effective routing).
+   Standing PM rule (2026-07-03): state the model and expected cost and get PM
+   confirmation BEFORE any live-agent run or coding-agent dispatch; the PM prefers
+   free/cheap models for the analysis agents and does not want surprise API bills.
 4. Optional final validation: rerun the single-profile live-agent isolated smoke to
    confirm agents now actually reach OpenRouter post-BaseAgent-fix (last attempt
    pre-fix failed with Gemini 404s).
 
 ## Known Issues / Machine-local
 - `.tmp-tests/`, `.codex-pytest-temp/`, `.pytest_cache/` have broken ACLs from
-  sandboxed agent runs (owned by another principal). Cleanup needs an elevated shell:
-  takeown /f <dir> /r /d y; icacls <dir> /reset /t /c /q; Remove-Item -Recurse -Force <dirs>
-  Until then the full suite locally fails ~25 tests on .tmp-tests permissions (CI unaffected).
+  sandboxed agent runs (owned by another principal). Cleanup needs an elevated
+  PowerShell, run from the repo root:
+
+  ```powershell
+  foreach ($d in ".tmp-tests", ".codex-pytest-temp", ".pytest_cache") {
+    takeown /f $d /r /d y
+    icacls $d /reset /t /c /q
+    Remove-Item -Recurse -Force $d
+  }
+  ```
+
+  Until then the full suite locally fails ~25 tests on `.tmp-tests` permissions (CI unaffected).
 - `data/alpha_pod.db.polluted-20260703.bak` (293MB, untracked) is the forensic backup
   from the 2026-07-03 isolation-leak incident; live DB was restored and verified clean
   (max queue id 91). Delete the .bak when no longer wanted.

--- a/.agent/session-state.md
+++ b/.agent/session-state.md
@@ -1,35 +1,49 @@
 # Session State
 
-**Updated:** 2026-07-03 05:50:28 UTC (merge conflict resolved 2026-07-03 by Claude supervisor session)
-**Agent:** Codex CLI
-**Project:** /workspace/ai-fund
+**Updated:** 2026-07-04 (post-merge handoff)
+**Agent:** Claude Code (supervisor) + Codex CLI (implementation)
+**Project:** C:/Projects/03-Finance/ai-fund
 
 ## Current Task
-Added a beginner-friendly `/learn-codebase` documentation page for PM/operator codebase review.
+M1 Weekly Loop v1 engineering surface is COMPLETE and merged to main via PR #77
+(squash commit `4d3fbe8`, all 7 CI checks green including the new
+backend-full-tests deep gate). Local repo is on a clean `main`;
+`plan/m1-weekly-loop-v1` is deleted.
 
-## Recent Actions
-- Created `docs/learn-codebase.md` with an approachable but detailed walkthrough for reviewing Alpha Pod as a non-engineer.
-- Added the page to the MkDocs top-level nav so it publishes at `/learn-codebase/`.
-- Linked the page from `docs/index.md` and `docs/handbook/index.md`.
-- Verified docs build with strict MkDocs.
+## What Shipped (PR #77 highlights)
+- CI deep gate (`backend-full-tests`: full offline suite on fresh runner)
+- `scripts/manual/weekly_preflight.py` (+ edgartools check) and runbook/friction-log/queue-checklist docs
+- Guided ticker workup CLI with: verified `--isolated-db` (all write paths resolve DB at call time), Data Freshness sections with [STALE] markers, working `--use-openrouter-free` routing (BaseAgent resolves LLM_BASE_URL/LLM_MODEL from env at construction), persisted per-run valuation JSON with CIQ historicals, friction-draft no-clobber
+- Five Codex-bot review rounds fully addressed (9 threads replied + resolved)
+- Systemic fix theme: import-time binding → use-time resolution (db/schema get_connection, BaseAgent, edgar_client, filing_retrieval, edgar_prefetch)
+- Semantic cache: fallback-scored filing bundles are never persisted
 
-## Next Steps
-- None for this task unless the PM wants this converted into an interactive app route later.
+## Next Steps (PM-facing, in order)
+1. Task 7 dry run: PM runs `docs/handbook/weekly-loop-session.md` end-to-end on one
+   ticker with an agent session open; use `docs/handbook/pm-queue-review-checklist.md`
+   for the queue click-through (all items currently NOT YET RUN).
+2. Sessions 1-4 (July): the M1 exit criteria clock. Real tickers, friction log per session.
+3. Suggested agent routing for live sessions:
+   `--use-openrouter-free --openrouter-model "openai/gpt-oss-120b:free" --openrouter-fallback-models "openai/gpt-oss-120b"`
+   (requires OPENROUTER_API_KEY in env; run banner now displays effective routing —
+   confirm model+cost with PM before any live-agent run, see Claude memory codex-model-routing).
+4. Optional final validation: rerun the single-profile live-agent isolated smoke to
+   confirm agents now actually reach OpenRouter post-BaseAgent-fix (last attempt
+   pre-fix failed with Gemini 404s).
 
-## Known Issues
-- `mkdocs build --strict` reports existing informational notices for docs pages that are not included in nav; the build succeeds.
+## Known Issues / Machine-local
+- `.tmp-tests/`, `.codex-pytest-temp/`, `.pytest_cache/` have broken ACLs from
+  sandboxed agent runs (owned by another principal). Cleanup needs an elevated shell:
+  takeown /f <dir> /r /d y; icacls <dir> /reset /t /c /q; Remove-Item -Recurse -Force <dirs>
+  Until then the full suite locally fails ~25 tests on .tmp-tests permissions (CI unaffected).
+- `data/alpha_pod.db.polluted-20260703.bak` (293MB, untracked) is the forensic backup
+  from the 2026-07-03 isolation-leak incident; live DB was restored and verified clean
+  (max queue id 91). Delete the .bak when no longer wanted.
+- Codex GitHub review bot is quota-exhausted; final head f53720d had supervisor review + CI only.
 
-## Notes
-- Verification passed:
-  - `NO_MKDOCS_2_WARNING=1 python -m mkdocs build --strict`
-
----
-
-## Carry-over open items from 2026-06-15 advanced-DCF session
-
-The completed work from that session (JSON unit fixes, advanced DCF workbook + reconciliation, guided-workup export wiring, TTWO unblock) is committed in `6bd2efe`..`e647d8e`. Still open:
-
-- **Bridge-mode guard:** if a future ticker returns `gordon_formula_mode == "bridge"`, add bridge-mode support in `_Context.reconcile()` and `_build_dcf_base`; do not remove the guard until formulas-engine workbook recalc reconciles.
-- **TTWO history (optional enrichment):** TTWO builds and reconciles without historicals; pull a CIQ Standard workbook for TTWO if the trend tab should be populated.
-- **Needs PM sign-off:** retire the legacy openpyxl writer and decide whether to keep the PowerQuery staging path. Do not rip out `src/stage_04_pipeline/export_service.py` without sign-off.
-- **Noisy but non-blocking:** `batch_runner --ticker ... --json` still makes SEC companyfacts and SPY/yfinance regime calls despite `--market-cache-only`.
+## Carry-over open items (from 2026-06-15 session, still valid)
+- Bridge-mode guard: if a ticker returns `gordon_formula_mode == "bridge"`, add support in
+  `_Context.reconcile()` / `_build_dcf_base` before removing the guard.
+- Needs PM sign-off: retire legacy openpyxl writer; keep-or-drop PowerQuery staging path.
+  Do not rip out `src/stage_04_pipeline/export_service.py` without sign-off.
+- TTWO CIQ history (optional): pull a CIQ Standard workbook to populate its trend tab.


### PR DESCRIPTION
One-file handoff-log update after PR #77 merged: records what shipped, PM-facing next steps (dry run, July sessions, agent routing), machine-local known issues, and carry-over items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)