### PR TITLE
fix: honor ALPHA_POD_MARKET_CACHE_ONLY in regime_model

### DIFF
--- a/src/stage_02_valuation/regime_model.py
+++ b/src/stage_02_valuation/regime_model.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import importlib.util
 import logging
+import os
 import pickle
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -89,6 +90,10 @@ def _fetch_training_features(lookback_days: int = 504) -> pd.DataFrame | None:
     Returns DataFrame with columns: spy_vol_20d, vix, slope_2s10s, ig_spread
     (z-score normalized, datetime index), or None on failure.
     """
+    if os.getenv("ALPHA_POD_MARKET_CACHE_ONLY", "0").strip().lower() in {"1", "true", "yes"}:
+        logger.debug("regime_model: market-cache-only mode; skipping live SPY/FRED download")
+        return None
+
     try:
         import pandas as pd
         import yfinance as yf


### PR DESCRIPTION
## Summary
- `_fetch_training_features()` in `regime_model.py` was calling `yf.download("SPY", ...)` unconditionally, even when `ALPHA_POD_MARKET_CACHE_ONLY=1` was set
- This meant `batch_runner --market-cache-only` (and `run_guided_ticker_workup.py --market-cache-only`) still triggered a live yfinance network call via `detect_current_regime()`
- Fix: add an early-return guard at the top of `_fetch_training_features()` that returns `None` when the flag is set, causing batch_runner to fall back to static 20/60/20 scenario weights (same as when HMM is unavailable)

## Test plan
- [ ] `pytest tests/test_regime_model.py -q` — 11 tests pass
- [ ] Smoke: `ALPHA_POD_MARKET_CACHE_ONLY=1 python -c "from src.stage_02_valuation.regime_model import detect_current_regime; r = detect_current_regime(); assert not r.available"` — returns unavailable without network call

🤖 Generated with [Claude Code](https://claude.com/claude-code)