### PR TITLE
fix: remove daily_refresh and refresh from PRINT_ALLOWLIST (TD-26)

### DIFF
--- a/tests/test_architecture_boundaries.py
+++ b/tests/test_architecture_boundaries.py
@@ -49,8 +49,6 @@ PRINT_ALLOWLIST = {
     "src/stage_01_screening/stage2_filter.py",
     "src/stage_01_screening/stage2_short_filter.py",
     "src/stage_02_valuation/create_template.py",
-    "src/stage_04_pipeline/daily_refresh.py",
-    "src/stage_04_pipeline/refresh.py",
 }
 
 SQLITE_CONNECT_ALLOWLIST = {


### PR DESCRIPTION
## Summary
`daily_refresh.py` and `refresh.py` were in `PRINT_ALLOWLIST` in `tests/test_architecture_boundaries.py`, implying they still had `print()` debt. They don't — both files already use `logging` with no `print()` calls. Removing them from the allowlist makes the boundary test enforce that state going forward.

## Test plan
- [x] `pytest tests/test_architecture_boundaries.py -q` → 4 passed
- [x] `pytest tests/ -q -p no:cacheprovider` → 790 passed, 1 skipped
- [ ] CI full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)